### PR TITLE
feat: 사용자 생성 기능 구현

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/user/controller/UserController.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.redhorse.deokhugam.domain.user.controller;
+
+import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
+import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
+import com.redhorse.deokhugam.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/users")
+@Slf4j
+public class UserController {
+
+  private final UserService userService;
+
+  @PostMapping()
+  public ResponseEntity<UserDto> createUser(@Valid @RequestBody UserRegisterRequest request) {
+
+    UserDto userDto = userService.createUser(request);
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(userDto);
+  }
+}

--- a/src/main/java/com/redhorse/deokhugam/domain/user/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/dto/request/UserRegisterRequest.java
@@ -1,0 +1,26 @@
+package com.redhorse.deokhugam.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserRegisterRequest(
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    String email,
+
+    @NotBlank(message = "이름은 필수 입력값입니다.")
+    @Size(min = 2, max = 20, message = "이름은 2 ~ 20자 이내여야 합니다.")
+    String nickname,
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+        message = "비밀번호는 8~20자여야 하며, 영문 대소문자, 숫자, 특수문자를 적어도 하나씩 포함해야 합니다."
+    )
+    String password
+) {
+
+}

--- a/src/main/java/com/redhorse/deokhugam/domain/user/dto/response/UserDto.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/dto/response/UserDto.java
@@ -1,0 +1,13 @@
+package com.redhorse.deokhugam.domain.user.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserDto(
+    UUID id,
+    String email,
+    String nickname,
+    Instant createdAt
+) {
+
+}

--- a/src/main/java/com/redhorse/deokhugam/domain/user/entity/User.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/entity/User.java
@@ -6,15 +6,18 @@ import com.redhorse.deokhugam.domain.dashboard.entity.PowerUser;
 import com.redhorse.deokhugam.domain.review.entity.Review;
 import com.redhorse.deokhugam.domain.review.entity.ReviewLike;
 import com.redhorse.deokhugam.global.entity.BaseUpdatableEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
-
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 
 @SQLRestriction("is_deleted = false")
 @Entity

--- a/src/main/java/com/redhorse/deokhugam/domain/user/exception/UserDuplicateException.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/exception/UserDuplicateException.java
@@ -1,0 +1,11 @@
+package com.redhorse.deokhugam.domain.user.exception;
+
+import com.redhorse.deokhugam.global.exception.ErrorCode;
+import java.util.Map;
+
+public class UserDuplicateException extends UserException {
+
+  public UserDuplicateException(String email) {
+    super(ErrorCode.USER_DUPLICATE, Map.of("email", email));
+  }
+}

--- a/src/main/java/com/redhorse/deokhugam/domain/user/exception/UserDuplicateException.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/exception/UserDuplicateException.java
@@ -6,6 +6,17 @@ import java.util.Map;
 public class UserDuplicateException extends UserException {
 
   public UserDuplicateException(String email) {
-    super(ErrorCode.USER_DUPLICATE, Map.of("email", email));
+    super(ErrorCode.USER_DUPLICATE, Map.of("email", maskEmail(email)));
+  }
+
+  private static String maskEmail(String email) {
+    if (email == null || !email.contains("@")) {
+      return "redacted";
+    }
+
+    String[] parts = email.split("@", 2);
+    String local = parts[0];
+    String maskedLocal = local.length() <= 2 ? "**" : local.substring(0, 2) + "***";
+    return maskedLocal + "@" + parts[1];
   }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/user/exception/UserException.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/exception/UserException.java
@@ -6,7 +6,8 @@ import com.redhorse.deokhugam.global.exception.GlobalException;
 import java.util.Map;
 
 public class UserException extends GlobalException {
-    public UserException(ErrorCode errorCode, Map<String, Object> details) {
-        super(errorCode, details);
-    }
+
+  public UserException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/exception/UserNotFoundException.java
@@ -6,7 +6,8 @@ import java.util.Map;
 import java.util.UUID;
 
 public class UserNotFoundException extends UserException {
-    public UserNotFoundException(UUID userId) {
-        super(ErrorCode.USER_NOT_FOUND, Map.of("user", userId));
-    }
+
+  public UserNotFoundException(UUID userId) {
+    super(ErrorCode.USER_NOT_FOUND, Map.of("user", userId));
+  }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/mapper/UserMapper.java
@@ -1,0 +1,16 @@
+package com.redhorse.deokhugam.domain.user.mapper;
+
+import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
+import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
+import com.redhorse.deokhugam.domain.user.entity.User;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+
+  // 유저 생성 DTO → Entity
+  User toEntity(UserRegisterRequest request);
+
+  // 유저 Entity → 유저 조회 DTO
+  UserDto toUserDto(User user);
+}

--- a/src/main/java/com/redhorse/deokhugam/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/repository/UserRepository.java
@@ -3,7 +3,18 @@ package com.redhorse.deokhugam.domain.user.repository;
 import com.redhorse.deokhugam.domain.user.entity.User;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
+
+  /**
+   * SQLRestriction("is_deleted = false") 를 우회하여
+   * 이메일 중복 검사를 하기 위해 nativeQuery 사용
+   */
+  @Query(value = """
+      SELECT COUNT(u.id) > 0
+      FROM  users u
+      WHERE u.email = :email
+      """, nativeQuery = true)
   Boolean existsUserByEmail(String email);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/repository/UserRepository.java
@@ -1,9 +1,9 @@
 package com.redhorse.deokhugam.domain.user.repository;
 
 import com.redhorse.deokhugam.domain.user.entity.User;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.UUID;
-
 public interface UserRepository extends JpaRepository<User, UUID> {
+  Boolean existsUserByEmail(String email);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/user/service/UserService.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/service/UserService.java
@@ -1,0 +1,9 @@
+package com.redhorse.deokhugam.domain.user.service;
+
+import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
+import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
+
+public interface UserService {
+
+  UserDto createUser(UserRegisterRequest request);
+}

--- a/src/main/java/com/redhorse/deokhugam/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/service/impl/UserServiceImpl.java
@@ -9,6 +9,7 @@ import com.redhorse.deokhugam.domain.user.repository.UserRepository;
 import com.redhorse.deokhugam.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,12 +29,19 @@ public class UserServiceImpl implements UserService {
       throw new UserDuplicateException(email);
     }
 
-    // DTO → Entity 변환
-    User user = userMapper.toEntity(request);
+    // 이메일 중복 검사 + 저장하는 짧은 시간 사이에
+    // 누군가 저장할 수도 있으므로 try문 사용
+    try {
+      // DTO → Entity 변환
+      User user = userMapper.toEntity(request);
+      // 저장 및 반환
+      userRepository.save(user);
 
-    // 저장 및 반환
-    userRepository.save(user);
+      return userMapper.toUserDto(user);
+    } catch (DataIntegrityViolationException e) {
+      log.error("중복 가입 시도 감지 (동시성 요청): {}", request.email());
 
-    return userMapper.toUserDto(user);
+      throw new UserDuplicateException(request.email());
+    }
   }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,39 @@
+package com.redhorse.deokhugam.domain.user.service.impl;
+
+import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
+import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
+import com.redhorse.deokhugam.domain.user.entity.User;
+import com.redhorse.deokhugam.domain.user.exception.UserDuplicateException;
+import com.redhorse.deokhugam.domain.user.mapper.UserMapper;
+import com.redhorse.deokhugam.domain.user.repository.UserRepository;
+import com.redhorse.deokhugam.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserServiceImpl implements UserService {
+
+  private final UserRepository userRepository;
+  private final UserMapper userMapper;
+
+  @Override
+  public UserDto createUser(UserRegisterRequest request) {
+    String email = request.email();
+
+    // 이메일 중복검사
+    if (userRepository.existsUserByEmail(email)) {
+      throw new UserDuplicateException(email);
+    }
+
+    // DTO → Entity 변환
+    User user = userMapper.toEntity(request);
+
+    // 저장 및 반환
+    userRepository.save(user);
+
+    return userMapper.toUserDto(user);
+  }
+}

--- a/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     // user
-    USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    USER_DUPLICATE("이미 존재하는 사용자입니다.", HttpStatus.CONFLICT);
 
     // review
 

--- a/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,105 @@
+package com.redhorse.deokhugam.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
+import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
+import com.redhorse.deokhugam.domain.user.service.UserService;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+@DisplayName("UserController 슬라이스 테스트")
+class UserControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private UserService userService;
+
+  @Test
+  @DisplayName("유저 회원가입 성공")
+  void createUser_Success() throws Exception {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "seongjo.park@gmail.com",
+        "박성조",
+        "Thisistest123***"
+    );
+
+    UserDto response = new UserDto(
+        UUID.randomUUID(),
+        request.email(),
+        request.nickname(),
+        Instant.now()
+    );
+
+    given(
+        userService.createUser(eq(request))
+    ).willReturn(response);
+
+    // when
+    var result = mockMvc.perform(post("/api/users")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    result.andExpect(status().isCreated())
+        .andExpect(jsonPath("$.email").value(request.email()))
+        .andExpect(jsonPath("$.nickname").value(request.nickname()));
+  }
+
+  @Test
+  @DisplayName("유저 회원가입 실패 - 잘못된 이메일 형식")
+  void createUser_InvalidEmail() throws Exception {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "seongjo.park",
+        "박성조",
+        "Thisistest123***"
+    );
+
+    // when
+    var result = mockMvc.perform(post("/api/users")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("유저 회원가입 실패 - 필수값 누락")
+  void createUser_BlankField() throws Exception {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "",
+        "박성조",
+        "Thisistest123***"
+    );
+
+    // when
+    var result = mockMvc.perform(post("/api/users")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
 import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
+import com.redhorse.deokhugam.domain.user.exception.UserDuplicateException;
 import com.redhorse.deokhugam.domain.user.service.UserService;
 import java.time.Instant;
 import java.util.UUID;
@@ -101,5 +102,27 @@ class UserControllerTest {
 
     // then
     result.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("유저 회원가입 실패 - 이메일 중복")
+  void createUser_DuplicateEmail() throws Exception {
+    // given
+    UserRegisterRequest request = new UserRegisterRequest(
+        "seongjo.park@gmail.com",
+        "박성조",
+        "Thisistest123***"
+    );
+
+    given(
+        userService.createUser(eq(request))
+    ).willThrow(new UserDuplicateException(request.email()));
+
+    // when & then
+    var result = mockMvc.perform(post("/api/users")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    result.andExpect(status().isConflict());
   }
 }

--- a/src/test/java/com/redhorse/deokhugam/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.redhorse.deokhugam.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.redhorse.deokhugam.domain.user.entity.User;
+import com.redhorse.deokhugam.global.config.JpaConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+@DisplayName("UserRepository 슬라이스 테스트")
+class UserRepositoryTest {
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("이메일로 유저 존재 여부 확인")
+  void existsUserByEmail() {
+    // given
+    String email = "seongjo.park@gmail.com";
+    User user = new User(
+        email,
+        "박성조",
+        "Thisistest123***"
+    );
+    userRepository.save(user);
+
+    // when
+    boolean exists = userRepository.existsUserByEmail(email);
+    boolean notExists = userRepository.existsUserByEmail("seongjo.park222@gmail.com");
+
+    // then
+    assertThat(exists).isTrue();
+    assertThat(notExists).isFalse();
+  }
+
+  @Test
+  @DisplayName("유저 저장 및 조회")
+  void saveAndFindUser() {
+    // given
+    User user = new User(
+        "seongjo.park@gmail.com",
+        "박성조",
+        "Thisistest123***"
+    );
+
+    // when
+    User savedUser = userRepository.save(user);
+
+    // then
+    assertThat(savedUser.getId()).isNotNull();
+    assertThat(savedUser.getEmail()).isEqualTo("seongjo.park@gmail.com");
+    assertThat(savedUser.getCreatedAt()).isNotNull();
+  }
+}

--- a/src/test/java/com/redhorse/deokhugam/domain/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/service/impl/UserServiceImplTest.java
@@ -1,0 +1,99 @@
+package com.redhorse.deokhugam.domain.user.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
+import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
+import com.redhorse.deokhugam.domain.user.entity.User;
+import com.redhorse.deokhugam.domain.user.exception.UserDuplicateException;
+import com.redhorse.deokhugam.domain.user.mapper.UserMapper;
+import com.redhorse.deokhugam.domain.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserServiceImpl 단위 테스트")
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Test
+    @DisplayName("유저 생성 성공")
+    void createUser_Success() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+            "seongjo.park@gmail.com",
+            "박성조",
+            "Thisistest123***"
+        );
+
+        User user = new User(
+            request.email(),
+            request.nickname(),
+            request.password()
+        );
+
+        UserDto userDto = new UserDto(
+            UUID.randomUUID(),
+            request.email(),
+            request.nickname(),
+            Instant.now()
+        );
+
+        given(
+            userRepository.existsUserByEmail(request.email())
+        ).willReturn(false);
+
+        given(
+            userMapper.toEntity(request)
+        ).willReturn(user);
+
+        given(
+            userMapper.toUserDto(user)
+        ).willReturn(userDto);
+
+        // when
+        UserDto result = userService.createUser(request);
+
+        // then
+        assertThat(result.email()).isEqualTo(request.email());
+        assertThat(result.nickname()).isEqualTo(request.nickname());
+        verify(userRepository).existsUserByEmail(request.email());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("유저 생성 실패 - 이메일 중복")
+    void createUser_DuplicateEmail() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+            "seongjo.park@gmail.com",
+            "박성조",
+            "Thisistest123***"
+        );
+
+        given(
+            userRepository.existsUserByEmail(request.email())
+        ).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.createUser(request))
+            .isInstanceOf(UserDuplicateException.class);
+    }
+}


### PR DESCRIPTION
## 작업 내용
> 어떤 작업을 했는지 간략히 설명해주세요.
- 사용자 생성 작업
- 사용자 생성 테스트 작업
  - `controller`, `service`, `repository`의 단위/슬라이스 테스트

## 관련 이슈
- 

## 변경 사항
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 테스트
- [X] 테스트 코드 작성
- [X] 로컬 테스트 완료

## 참고 사항
> 리뷰어가 알아야 할 내용이 있다면 작성해주세요.

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 회원가입 REST API 추가: POST /api/users로 회원 생성(성공 시 201 Created, User 응답)
  * 요청/응답 DTO 추가 및 등록 매핑 지원
  * 에러 응답에 이메일 일부 마스킹 적용

* **검증 강화**
  * 이메일 형식, 닉네임 길이(2-20), 비밀번호 강도(8-20자·영문·숫자·특수문자) 검증 적용

* **테스트**
  * 컨트롤러·서비스·레포지토리 단위 및 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->