### PR TITLE
feat: 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/controller/CommentController.java
@@ -2,13 +2,18 @@ package com.redhorse.deokhugam.domain.comment.controller;
 
 import com.redhorse.deokhugam.domain.comment.dto.CommentCreateRequest;
 import com.redhorse.deokhugam.domain.comment.dto.CommentDto;
+import com.redhorse.deokhugam.domain.comment.dto.CommentUpdateRequest;
 import com.redhorse.deokhugam.domain.comment.service.CommentService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,4 +34,16 @@ public class CommentController {
         .body(comment);
   }
 
+  @PatchMapping("/{commentId}")
+  public ResponseEntity<CommentDto> update(
+      @PathVariable UUID commentId,
+      @RequestHeader("Deokhugam-Request-User-ID") UUID requestUserId,
+      @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
+  ){
+    CommentDto comment = commentService.update(commentId, requestUserId, commentUpdateRequest);
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(comment);
+  }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/dto/CommentUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.redhorse.deokhugam.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentUpdateRequest(
+    @NotBlank(message = "댓글 내용은 비어있을 수 없습니다.")
+    String content
+) {
+
+}

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
@@ -1,9 +1,12 @@
 package com.redhorse.deokhugam.domain.comment.repository;
 
 import com.redhorse.deokhugam.domain.comment.entity.Comment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
+
+  Optional<Comment> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentService.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentService.java
@@ -2,6 +2,8 @@ package com.redhorse.deokhugam.domain.comment.service;
 
 import com.redhorse.deokhugam.domain.comment.dto.CommentCreateRequest;
 import com.redhorse.deokhugam.domain.comment.dto.CommentDto;
+import com.redhorse.deokhugam.domain.comment.dto.CommentUpdateRequest;
+import java.util.UUID;
 
 public interface CommentService {
 
@@ -9,6 +11,7 @@ public interface CommentService {
   CommentDto create(CommentCreateRequest commentCreateRequest);
 
   // 댓글 수정
+  CommentDto update(UUID commentId, UUID requestUserId, CommentUpdateRequest commentUpdateRequest);
 
   // 댓글 상세 조회
 

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -2,6 +2,7 @@ package com.redhorse.deokhugam.domain.comment.service;
 
 import com.redhorse.deokhugam.domain.comment.dto.CommentCreateRequest;
 import com.redhorse.deokhugam.domain.comment.dto.CommentDto;
+import com.redhorse.deokhugam.domain.comment.dto.CommentUpdateRequest;
 import com.redhorse.deokhugam.domain.comment.entity.Comment;
 import com.redhorse.deokhugam.domain.comment.mapper.CommentMapper;
 import com.redhorse.deokhugam.domain.comment.repository.CommentRepository;
@@ -40,5 +41,20 @@ public class CommentServiceImpl implements CommentService {
     Comment savedComment = commentRepository.save(comment);
 
     return commentMapper.toDto(savedComment);
+  }
+
+  @Override
+  public CommentDto update(UUID commentId, UUID requestUserId,
+      CommentUpdateRequest commentUpdateRequest) {
+    Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+        .orElseThrow(() -> new IllegalArgumentException("Comment Not Found"));
+
+    if (!comment.getUser().getId().equals(requestUserId)) {
+      throw new IllegalArgumentException("자신이 작성한 댓글만 수정할 수 있습니다.");
+    }
+
+    comment.update(commentUpdateRequest.content());
+
+    return commentMapper.toDto(comment);
   }
 }

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/controller/CommentControllerTest.java
@@ -1,7 +1,9 @@
 package com.redhorse.deokhugam.domain.comment.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhorse.deokhugam.domain.comment.dto.CommentCreateRequest;
 import com.redhorse.deokhugam.domain.comment.dto.CommentDto;
+import com.redhorse.deokhugam.domain.comment.dto.CommentUpdateRequest;
 import com.redhorse.deokhugam.domain.comment.service.CommentService;
 import java.time.Instant;
 import java.util.UUID;
@@ -102,5 +105,50 @@ class CommentControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(invalidRequest)))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("댓글 수정 요청이 성공적으로 처리되어야 한다.")
+  void update() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+    CommentUpdateRequest commentReq = new CommentUpdateRequest("댓글 수정 테스트");
+
+    CommentDto responseDto = new CommentDto(
+        commentId, UUID.randomUUID(), requestUserId, "감자", "댓글 수정 테스트",
+        Instant.now(), Instant.now()
+    );
+
+    given(commentService.update(eq(commentId), eq(requestUserId), any(CommentUpdateRequest.class))).willReturn(responseDto);
+
+    // when & then
+    mockMvc.perform(patch("/api/comments/{commentId}", commentId)
+            .header("Deokhugam-Request-User-ID", requestUserId.toString())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(commentReq)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(commentId.toString()))
+        .andExpect(jsonPath("$.content").value("댓글 수정 테스트"))
+        .andExpect(jsonPath("$.userId").value(requestUserId.toString()));
+  }
+
+  @Test
+  @DisplayName("댓글 수정 실패 - 작성자가 아닌 유저가 요청하면 500을 반환한다")
+  void update_WhenUserIsNotAuthor_ShouldThrowException() throws Exception {
+    // given
+    UUID commentId = UUID.randomUUID();
+    UUID requestUserId = UUID.randomUUID();
+    CommentUpdateRequest request = new CommentUpdateRequest("댓글 수정 테스트");
+
+    given(commentService.update(eq(commentId), eq(requestUserId), any(CommentUpdateRequest.class)))
+        .willThrow(new IllegalArgumentException("자신이 작성한 댓글만 수정할 수 있습니다."));
+
+    // when & then
+    mockMvc.perform(patch("/api/comments/{commentId}", commentId)
+            .header("Deokhugam-Request-User-ID", requestUserId.toString())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isInternalServerError());
   }
 }

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
@@ -3,14 +3,17 @@ package com.redhorse.deokhugam.domain.comment.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.redhorse.deokhugam.domain.comment.dto.CommentCreateRequest;
 import com.redhorse.deokhugam.domain.comment.dto.CommentDto;
+import com.redhorse.deokhugam.domain.comment.dto.CommentUpdateRequest;
 import com.redhorse.deokhugam.domain.comment.entity.Comment;
 import com.redhorse.deokhugam.domain.comment.mapper.CommentMapper;
 import com.redhorse.deokhugam.domain.comment.repository.CommentRepository;
@@ -72,7 +75,8 @@ class CommentServiceTest {
       given(commentRepository.save(any(Comment.class)))
           .willAnswer(invocation -> invocation.getArgument(0));
 
-      CommentDto commentDto = new CommentDto(commentId, reviewId, userId, mockUser.getNickname(), "하이",
+      CommentDto commentDto = new CommentDto(commentId, reviewId, userId, mockUser.getNickname(),
+          "하이",
           now, now);
       given(commentMapper.toDto(any(Comment.class))).willReturn(commentDto);
 
@@ -89,16 +93,17 @@ class CommentServiceTest {
     @Test
     @DisplayName("댓글 등록 실패 - 리뷰가 유효하지 않을 경우")
     void create_WhenNotFoundReview_ShouldThrowException() {
+      // given
       UUID invalidReviewId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
       CommentCreateRequest commentReq = new CommentCreateRequest(invalidReviewId, userId, "하이");
 
       given(reviewRepository.findById(eq(invalidReviewId))).willReturn(Optional.empty());
 
+      // when & then
       assertThatThrownBy(() -> commentService.create(commentReq))
           .isInstanceOf(IllegalArgumentException.class);
 
-      // then
       then(commentRepository).should(never()).save(any(Comment.class));
       then(userRepository).should(never()).findById(eq(userId));
     }
@@ -106,6 +111,7 @@ class CommentServiceTest {
     @Test
     @DisplayName("댓글 등록 실패 - 사용자가 유효하지 않을 경우")
     void create_WhenNotFoundUser_ShouldThrowException() {
+      // given
       UUID reviewId = UUID.randomUUID();
       UUID invalidUserId = UUID.randomUUID();
       CommentCreateRequest commentReq = new CommentCreateRequest(reviewId, invalidUserId, "하이");
@@ -114,11 +120,60 @@ class CommentServiceTest {
       given(reviewRepository.findById(eq(reviewId))).willReturn(Optional.of(mockReview));
       given(userRepository.findById(eq(invalidUserId))).willReturn(Optional.empty());
 
+      // when & then
       assertThatThrownBy(() -> commentService.create(commentReq))
           .isInstanceOf(IllegalArgumentException.class);
 
       // then
       then(commentRepository).should(never()).save(any(Comment.class));
+    }
+
+    @Test
+    @DisplayName("댓글 수정 성공")
+    void update_ShouldReturnCommentDto() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+      CommentUpdateRequest commentReq = new CommentUpdateRequest("댓글 수정 테스트");
+
+      User mockUser = mock(User.class);
+      given(mockUser.getId()).willReturn(requestUserId);
+
+      Comment mockComment = mock(Comment.class);
+      given(mockComment.getUser()).willReturn(mockUser);
+      given(commentRepository.findByIdAndDeletedAtIsNull(eq(commentId))).willReturn(Optional.of(mockComment));
+
+      CommentDto expectedDto = new CommentDto(commentId, UUID.randomUUID(), requestUserId, "감자", "댓글 수정 테스트", Instant.now(), Instant.now());
+      given(commentMapper.toDto(mockComment)).willReturn(expectedDto);
+
+      // when
+      CommentDto result = commentService.update(commentId, requestUserId, commentReq);
+
+      // then
+      assertThat(result.content()).isEqualTo("댓글 수정 테스트");
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패 - 댓글 작성자가 아닐 경우")
+    void update_WhenAuthorIsDifferent_ShouldThrowException() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+      UUID authorId = UUID.randomUUID();
+      CommentUpdateRequest commentReq = new CommentUpdateRequest("댓글 수정 테스트");
+
+      User mockAuthor = mock(User.class);
+      given(mockAuthor.getId()).willReturn(authorId);
+
+      Comment mockComment = mock(Comment.class);
+      given(mockComment.getUser()).willReturn(mockAuthor);
+      given(commentRepository.findByIdAndDeletedAtIsNull(eq(commentId))).willReturn(Optional.of(mockComment));
+
+      // when & then
+      assertThatThrownBy(() -> commentService.update(commentId, requestUserId, commentReq))
+          .isInstanceOf(IllegalArgumentException.class);
+
+      verify(mockComment, never()).update(anyString());
     }
   }
 }


### PR DESCRIPTION
## 작업 내용
> 어떤 작업을 했는지 간략히 설명해주세요.
- 댓글 수정 기능 구현했습니다.
- 헤더로부터 댓글을 수정하고자 하는 요청자의 UUID를 받아와서 댓글의 작성자와 비교하고, 일치하는 경우에만 댓글 수정 가능하도록 하였습니다.
- 또한, 댓글 조회 시 논리 삭제가 이루어진 댓글들을 조회되지 않도록 하였습니다.
- 위 사항은 댓글 상세 조회 기능 구현 시 테스트 코드에 추가하도록 하겠습니다.

## 관련 이슈
- closes #이슈번호

## 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 테스트
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료

## 참고 사항
> 리뷰어가 알아야 할 내용이 있다면 작성해주세요.
- 코드래빗이 헤더에서 요청자의 UUID를 직접 꺼내서 쓰는 것이 위험하다고 하는데 대안책이 Spring security라고 합니다. 제가 시간이 남으면 심화로 한 번 개선해보겠습니다.

### 스크린샷 (선택)
<img width="1823" height="287" alt="스크린샷 2026-03-04 134402" src="https://github.com/user-attachments/assets/412c96b8-4d05-4907-be3d-3339ceb0fb7a" />
- 6번 레코드 "댓글 수정 테스트"로 내용 변경된 것 확인!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 수정 기능 추가: 사용자가 자신의 댓글을 수정할 수 있습니다.
  * 댓글 내용 유효성 검사: 빈 댓글 수정 방지
  * 권한 검증: 댓글 작성자만 수정 가능

* **테스트**
  * 댓글 수정 기능에 대한 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->