### PR TITLE
feat: 사용자 인증 기능 추가

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/mapper/UserMapper.java
@@ -4,11 +4,17 @@ import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
 import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
 import com.redhorse.deokhugam.domain.user.entity.User;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
 
   // 유저 생성 DTO → Entity
+  @Mapping(target = "comments", ignore = true)
+  @Mapping(target = "reviews", ignore = true)
+  @Mapping(target = "reviewLikes", ignore = true)
+  @Mapping(target = "alarms", ignore = true)
+  @Mapping(target = "powerUsers", ignore = true)
   User toEntity(UserRegisterRequest request);
 
   // 유저 Entity → 유저 조회 DTO

--- a/src/main/java/com/redhorse/deokhugam/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/user/repository/UserRepository.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
 
   /**

--- a/src/main/java/com/redhorse/deokhugam/global/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/redhorse/deokhugam/global/config/AuthenticationInterceptor.java
@@ -28,11 +28,14 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     try {
       // UUID 패턴인지 확인
       // String → UUID 변환할 때, String이 UUID 형식이 아니면 IllegalArgumentException 에러 발생하기 때문에 try문 사용
-      UUID.fromString(userIdHeader);
+      UUID userId = UUID.fromString(userIdHeader);
+
+      // 컨트롤러에서 쉽게 추출하기 위함
+      request.setAttribute("requestUserId", userId);
+
+      return true;
     } catch (IllegalArgumentException e) {
       throw new AuthenticationException();
     }
-
-    return true;
   }
 }

--- a/src/main/java/com/redhorse/deokhugam/global/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/redhorse/deokhugam/global/config/AuthenticationInterceptor.java
@@ -1,0 +1,48 @@
+package com.redhorse.deokhugam.global.config;
+
+import com.redhorse.deokhugam.domain.user.exception.UserNotFoundException;
+import com.redhorse.deokhugam.domain.user.repository.UserRepository;
+import com.redhorse.deokhugam.global.exception.AuthenticationException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      Object handler
+  ) throws Exception {
+    String userIdHeader = request.getHeader("Deokhugam-Request-User-ID");
+
+    // 헤더 누락 확인
+    if (userIdHeader == null || userIdHeader.isEmpty()) {
+      throw new AuthenticationException();
+    }
+
+    UUID userId;
+
+    try {
+      // String → UUID 변환할 때
+      // String이 UUID 형식이 아니면 IllegalArgumentException 에러나기때문에 try문 사용
+      userId = UUID.fromString(userIdHeader);
+    } catch (IllegalArgumentException e) {
+      throw new AuthenticationException();
+    }
+
+    // 실제 유저가 존재하는지 확인
+    userRepository.findById(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+
+    return true;
+  }
+}

--- a/src/main/java/com/redhorse/deokhugam/global/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/redhorse/deokhugam/global/config/AuthenticationInterceptor.java
@@ -1,6 +1,5 @@
 package com.redhorse.deokhugam.global.config;
 
-import com.redhorse.deokhugam.domain.user.exception.UserNotFoundException;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
 import com.redhorse.deokhugam.global.exception.AuthenticationException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,7 +40,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     // 실제 유저가 존재하는지 확인
     userRepository.findById(userId)
-        .orElseThrow(() -> new UserNotFoundException(userId));
+        .orElseThrow(AuthenticationException::new);
 
     return true;
   }

--- a/src/main/java/com/redhorse/deokhugam/global/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/redhorse/deokhugam/global/config/AuthenticationInterceptor.java
@@ -1,6 +1,5 @@
 package com.redhorse.deokhugam.global.config;
 
-import com.redhorse.deokhugam.domain.user.repository.UserRepository;
 import com.redhorse.deokhugam.global.exception.AuthenticationException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -12,8 +11,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 @RequiredArgsConstructor
 public class AuthenticationInterceptor implements HandlerInterceptor {
-
-  private final UserRepository userRepository;
 
   @Override
   public boolean preHandle(
@@ -28,19 +25,13 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
       throw new AuthenticationException();
     }
 
-    UUID userId;
-
     try {
-      // String → UUID 변환할 때
-      // String이 UUID 형식이 아니면 IllegalArgumentException 에러나기때문에 try문 사용
-      userId = UUID.fromString(userIdHeader);
+      // UUID 패턴인지 확인
+      // String → UUID 변환할 때, String이 UUID 형식이 아니면 IllegalArgumentException 에러 발생하기 때문에 try문 사용
+      UUID.fromString(userIdHeader);
     } catch (IllegalArgumentException e) {
       throw new AuthenticationException();
     }
-
-    // 실제 유저가 존재하는지 확인
-    userRepository.findById(userId)
-        .orElseThrow(AuthenticationException::new);
 
     return true;
   }

--- a/src/main/java/com/redhorse/deokhugam/global/config/WebMvcConfig.java
+++ b/src/main/java/com/redhorse/deokhugam/global/config/WebMvcConfig.java
@@ -7,13 +7,33 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
-public class WebMvcConfig implements WebMvcConfigurer
-{
-    private final MDCLoggingInterceptor mdcLoggingInterceptor;
+public class WebMvcConfig implements WebMvcConfigurer {
 
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(mdcLoggingInterceptor)
-                .addPathPatterns("/**");
-    }
+  private final MDCLoggingInterceptor mdcLoggingInterceptor;
+  private final AuthenticationInterceptor authenticationInterceptor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    // MDC 로그 인터셉터
+    registry.addInterceptor(mdcLoggingInterceptor)
+        .addPathPatterns("/**")
+        .order(1);
+
+    // 인증 헤더확인 인터셉터
+    registry
+        .addInterceptor(authenticationInterceptor)
+        .addPathPatterns("/**")
+        .excludePathPatterns(
+            // 인증 제외 대상
+            "/",
+            "/api/users/login",
+            "/api/users/signup",
+            "/favicon.ico",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/static/**",
+            "/images/**"
+        )
+        .order(2);
+  }
 }

--- a/src/main/java/com/redhorse/deokhugam/global/config/WebMvcConfig.java
+++ b/src/main/java/com/redhorse/deokhugam/global/config/WebMvcConfig.java
@@ -26,14 +26,16 @@ public class WebMvcConfig implements WebMvcConfigurer {
         .excludePathPatterns(
             // 인증 제외 대상
             "/",
+            "/index.html",
+            "/api/users",
             "/api/users/login",
-            "/api/users/signup",
-            "/favicon.ico",
             "/swagger-ui/**",
             "/v3/api-docs/**",
-            "/static/**",
-            "/images/**"
+            "/assets/**",
+            "/images/**",
+            "/favicon.ico"
         )
         .order(2);
+
   }
 }

--- a/src/main/java/com/redhorse/deokhugam/global/config/WebMvcConfig.java
+++ b/src/main/java/com/redhorse/deokhugam/global/config/WebMvcConfig.java
@@ -1,6 +1,7 @@
 package com.redhorse.deokhugam.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -12,6 +13,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
   private final MDCLoggingInterceptor mdcLoggingInterceptor;
   private final AuthenticationInterceptor authenticationInterceptor;
 
+  @Value("${auth.interceptor.enabled:true}")
+  private boolean authInterceptorEnabled;
+
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     // MDC 로그 인터셉터
@@ -19,23 +23,26 @@ public class WebMvcConfig implements WebMvcConfigurer {
         .addPathPatterns("/**")
         .order(1);
 
-    // 인증 헤더확인 인터셉터
-    registry
-        .addInterceptor(authenticationInterceptor)
-        .addPathPatterns("/**")
-        .excludePathPatterns(
-            // 인증 제외 대상
-            "/",
-            "/index.html",
-            "/api/users",
-            "/api/users/login",
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
-            "/assets/**",
-            "/images/**",
-            "/favicon.ico"
-        )
-        .order(2);
-
+    // 기본으로 실행되지만 테스트에서만 안되게 막음
+    // application-test.yaml의 auth.interceptor.enabled 확인
+    if (authInterceptorEnabled) {
+      // 인증 헤더확인 인터셉터
+      registry
+          .addInterceptor(authenticationInterceptor)
+          .addPathPatterns("/**")
+          .excludePathPatterns(
+              // 인증 제외 대상
+              "/",
+              "/index.html",
+              "/api/users",
+              "/api/users/login",
+              "/swagger-ui/**",
+              "/v3/api-docs/**",
+              "/assets/**",
+              "/images/**",
+              "/favicon.ico"
+          )
+          .order(2);
+    }
   }
 }

--- a/src/main/java/com/redhorse/deokhugam/global/exception/AuthenticationException.java
+++ b/src/main/java/com/redhorse/deokhugam/global/exception/AuthenticationException.java
@@ -1,0 +1,16 @@
+package com.redhorse.deokhugam.global.exception;
+
+import java.util.Map;
+
+public class AuthenticationException extends GlobalException {
+
+  public AuthenticationException() {
+    super(
+        ErrorCode.UNAUTHORIZED_USER,
+        Map.of(
+            "header", "인증 헤더 확인이 필요합니다.",
+            "description", "인증을 위해 유효한 사용자 ID가 필요합니다."
+        )
+    );
+  }
+}

--- a/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     USER_DUPLICATE("이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),
     LOGIN_FAILED("아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    UNAUTHORIZED_USER("로그인이 필요한 서비스입니다.", HttpStatus.UNAUTHORIZED),
 
     // review
 

--- a/src/test/java/com/redhorse/deokhugam/domain/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/alarm/controller/AlarmControllerTest.java
@@ -1,16 +1,5 @@
 package com.redhorse.deokhugam.domain.alarm.controller;
 
-import com.redhorse.deokhugam.domain.alarm.service.AlarmService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.UUID;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -18,7 +7,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.redhorse.deokhugam.domain.alarm.service.AlarmService;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
 @WebMvcTest(AlarmController.class)
+@ActiveProfiles("test")
 class AlarmControllerTest {
 
     @Autowired

--- a/src/test/java/com/redhorse/deokhugam/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/review/controller/ReviewControllerTest.java
@@ -23,10 +23,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ReviewController.class)
+@ActiveProfiles("test")
 public class ReviewControllerTest {
 
   @Autowired

--- a/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,5 @@
 package com.redhorse.deokhugam.domain.user.controller;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -19,7 +18,6 @@ import com.redhorse.deokhugam.global.config.AuthenticationInterceptor;
 import com.redhorse.deokhugam.global.config.MDCLoggingInterceptor;
 import java.time.Instant;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,17 +47,6 @@ class UserControllerTest {
 
   @MockitoBean
   private AuthenticationInterceptor authenticationInterceptor;
-
-  @BeforeEach
-  void setUp() throws Exception {
-    given(
-        mdcLoggingInterceptor.preHandle(any(), any(), any())
-    ).willReturn(true);
-
-    given(
-        authenticationInterceptor.preHandle(any(), any(), any())
-    ).willReturn(true);
-  }
 
   @Test
   @DisplayName("유저 회원가입 성공")

--- a/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
@@ -14,8 +14,6 @@ import com.redhorse.deokhugam.domain.user.exception.UserDuplicateException;
 import com.redhorse.deokhugam.domain.user.exception.UserLoginFailedException;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
 import com.redhorse.deokhugam.domain.user.service.UserService;
-import com.redhorse.deokhugam.global.config.AuthenticationInterceptor;
-import com.redhorse.deokhugam.global.config.MDCLoggingInterceptor;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -23,11 +21,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserController.class)
 @DisplayName("UserController 슬라이스 테스트")
+@ActiveProfiles("test")
 class UserControllerTest {
 
   @Autowired
@@ -41,12 +41,6 @@ class UserControllerTest {
 
   @MockitoBean
   private UserRepository userRepository;
-
-  @MockitoBean
-  private MDCLoggingInterceptor mdcLoggingInterceptor;
-
-  @MockitoBean
-  private AuthenticationInterceptor authenticationInterceptor;
 
   @Test
   @DisplayName("유저 회원가입 성공")

--- a/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.redhorse.deokhugam.domain.user.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -7,12 +8,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhorse.deokhugam.domain.user.dto.request.UserLoginRequest;
 import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
 import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
 import com.redhorse.deokhugam.domain.user.exception.UserDuplicateException;
+import com.redhorse.deokhugam.domain.user.exception.UserLoginFailedException;
+import com.redhorse.deokhugam.domain.user.repository.UserRepository;
 import com.redhorse.deokhugam.domain.user.service.UserService;
+import com.redhorse.deokhugam.global.config.AuthenticationInterceptor;
+import com.redhorse.deokhugam.global.config.MDCLoggingInterceptor;
 import java.time.Instant;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +40,26 @@ class UserControllerTest {
 
   @MockitoBean
   private UserService userService;
+
+  @MockitoBean
+  private UserRepository userRepository;
+
+  @MockitoBean
+  private MDCLoggingInterceptor mdcLoggingInterceptor;
+
+  @MockitoBean
+  private AuthenticationInterceptor authenticationInterceptor;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    given(
+        mdcLoggingInterceptor.preHandle(any(), any(), any())
+    ).willReturn(true);
+
+    given(
+        authenticationInterceptor.preHandle(any(), any(), any())
+    ).willReturn(true);
+  }
 
   @Test
   @DisplayName("유저 회원가입 성공")
@@ -124,5 +151,94 @@ class UserControllerTest {
         .content(objectMapper.writeValueAsString(request)));
 
     result.andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("로그인 성공")
+  void login_Success() throws Exception {
+    // given
+    UserLoginRequest request = new UserLoginRequest(
+        "seongjo.park@gmail.com",
+        "Thisistest123***"
+    );
+
+    UserDto response = new UserDto(
+        UUID.randomUUID(),
+        request.email(),
+        "박성조",
+        Instant.now()
+    );
+
+    given(
+        userService.login(eq(request))
+    ).willReturn(response);
+
+    // when
+    var result = mockMvc.perform(post("/api/users/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    result.andExpect(status().isOk())
+        .andExpect(jsonPath("$.email").value(request.email()))
+        .andExpect(jsonPath("$.nickname").value(response.nickname()));
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 잘못된 이메일 형식")
+  void login_InvalidEmail() throws Exception {
+    // given
+    UserLoginRequest request = new UserLoginRequest(
+        "seongjo.park",
+        "Thisistest123***"
+    );
+
+    // when
+    var result = mockMvc.perform(post("/api/users/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 필수값 누락")
+  void login_BlankField() throws Exception {
+    // given
+    UserLoginRequest request = new UserLoginRequest(
+        "",
+        "Thisistest123***"
+    );
+
+    // when
+    var result = mockMvc.perform(post("/api/users/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 계정 정보 불일치")
+  void login_Failed() throws Exception {
+    // given
+    UserLoginRequest request = new UserLoginRequest(
+        "wrong@gmail.com",
+        "wrongpassword"
+    );
+
+    given(
+        userService.login(eq(request))
+    ).willThrow(new UserLoginFailedException());
+
+    // when
+    var result = mockMvc.perform(post("/api/users/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    result.andExpect(status().isUnauthorized());
   }
 }

--- a/src/test/java/com/redhorse/deokhugam/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/repository/UserRepositoryTest.java
@@ -57,4 +57,29 @@ class UserRepositoryTest {
     assertThat(savedUser.getEmail()).isEqualTo("seongjo.park@gmail.com");
     assertThat(savedUser.getCreatedAt()).isNotNull();
   }
+
+  @Test
+  @DisplayName("이메일로 유저 조회")
+  void findByEmail() {
+    // given
+    String email = "seongjo.park@gmail.com";
+
+    User user = new User(
+        email,
+        "박성조",
+        "Thisistest123***"
+    );
+    userRepository.save(user);
+
+    // when
+    var foundUser = userRepository.findByEmail(email);
+    var notFoundUser = userRepository.findByEmail("notfound@gmail.com");
+
+    // then
+    assertThat(foundUser).isPresent();
+    assertThat(
+        foundUser.get().getEmail()
+    ).isEqualTo(email);
+    assertThat(notFoundUser).isEmpty();
+  }
 }

--- a/src/test/java/com/redhorse/deokhugam/domain/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/service/impl/UserServiceImplTest.java
@@ -5,13 +5,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.redhorse.deokhugam.domain.user.dto.request.UserLoginRequest;
 import com.redhorse.deokhugam.domain.user.dto.request.UserRegisterRequest;
 import com.redhorse.deokhugam.domain.user.dto.response.UserDto;
 import com.redhorse.deokhugam.domain.user.entity.User;
 import com.redhorse.deokhugam.domain.user.exception.UserDuplicateException;
+import com.redhorse.deokhugam.domain.user.exception.UserLoginFailedException;
 import com.redhorse.deokhugam.domain.user.mapper.UserMapper;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,5 +98,86 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.createUser(request))
             .isInstanceOf(UserDuplicateException.class);
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_Success() {
+        // given
+        UserLoginRequest request = new UserLoginRequest(
+            "seongjo.park@gmail.com",
+            "Thisistest123***"
+        );
+
+        User user = new User(
+            request.email(),
+            "박성조",
+            request.password()
+        );
+
+        UserDto userDto = new UserDto(
+            UUID.randomUUID(),
+            user.getEmail(),
+            user.getNickname(),
+            Instant.now()
+        );
+
+        given(
+            userRepository.findByEmail(request.email())
+        ).willReturn(Optional.of(user));
+
+        given(
+            userMapper.toUserDto(user)
+        ).willReturn(userDto);
+
+        // when
+        UserDto result = userService.login(request);
+
+        // then
+        assertThat(result.email()).isEqualTo(request.email());
+        assertThat(result.nickname()).isEqualTo(user.getNickname());
+        verify(userRepository).findByEmail(request.email());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void login_WrongPassword() {
+        // given
+        UserLoginRequest request = new UserLoginRequest(
+            "seongjo.park@gmail.com",
+            "Thisistest123***"
+        );
+
+        User user = new User(
+            request.email(),
+            "박성조",
+            "THIS_IS_WRONG_123"
+        );
+
+        given(
+            userRepository.findByEmail(request.email())
+        ).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> userService.login(request))
+            .isInstanceOf(UserLoginFailedException.class);
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 존재하지 않는 유저")
+    void login_UserNotFound() {
+        // given
+        UserLoginRequest request = new UserLoginRequest(
+            "seongjo.park@gmail.com",
+            "Thisistest123***"
+        );
+
+        given(
+            userRepository.findByEmail(request.email())
+        ).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.login(request))
+            .isInstanceOf(UserLoginFailedException.class);
     }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -24,3 +24,8 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
     org.springframework.test: debug
+
+# 인증 인터셉터
+auth:
+  interceptor:
+    enabled: false


### PR DESCRIPTION
## 작업 내용
> 어떤 작업을 했는지 간략히 설명해주세요.
- 로그인 테스트 코드 작성
- `UserMapper`수정
- 헤더로 `Deokhugam-Request-User-ID`를 보낸 사용자만 API 사용할 수 있도록 작업
  - 원활한 접속과 개발을 위해 아래 항목 제외
    - `"/"`
    - `"/index.html"`
    - `"/api/users"`
    - `"/api/users/login"`
    - `"/swagger-ui/**"`
    - `"/v3/api-docs/**"`
    - `"/assets/**"`
    - `"/images/**"`
    - `"/favicon.ico"`

## 관련 이슈
- 

## 변경 사항
- [X] 기능 추가
- [ ] 버그 수정
- [X] 리팩토링
- [ ] 기타

## 테스트
- [X] 테스트 코드 작성
- [X] 로컬 테스트 완료

## 참고 사항
> 리뷰어가 알아야 할 내용이 있다면 작성해주세요.

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 요청 헤더 기반 사용자 인증 추가: "Deokhugam-Request-User-ID"로 검증하고 인증 예외 처리 및 상태 코드(미인증) 도입.
  * 인증 인터셉터 등록에 순서 및 경로 제외 목록 적용.

* **Chores**
  * 인증 인터셉터를 설정 플래그로 활성/비활성화 가능하도록 구성 업데이트.
  * 사용자 매핑 시 연관 컬렉션을 채우지 않도록 매핑 동작 조정.

* **Tests**
  * 로그인 성공/실패 시나리오, 저장소 조회 및 테스트 프로파일(인증 비활성화) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->