### PR TITLE
fix: 도서 정보 불러오기 시 썸네일 이미지가 표시되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/infra/naver/NaverBookProvider.java
+++ b/src/main/java/com/redhorse/deokhugam/infra/naver/NaverBookProvider.java
@@ -4,19 +4,25 @@ import com.redhorse.deokhugam.infra.naver.dto.NaverBookDto;
 import com.redhorse.deokhugam.infra.naver.dto.NaverBookResponse.NaverBookItem;
 import com.redhorse.deokhugam.infra.naver.exception.NaverBookNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLConnection;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class NaverBookProvider
 {
     private final NaverBookClient naverBookClient;
+
+    private static final int CONNECTION_TIMEOUT_MS = 5000; // 5초
+    private static final int READ_TIMEOUT_MS = 10000;      // 10초
 
     /**
      * ISBN으로 네이버 도서 정보를 조회하여 NaverBooktDto로 반환한다.
@@ -28,6 +34,8 @@ public class NaverBookProvider
     public NaverBookDto getBookInfoByIsbn(String isbn) {
         NaverBookItem item = naverBookClient.fetchInfoByIsbn(isbn)
                 .orElseThrow(() -> new NaverBookNotFoundException(isbn));
+
+        log.info("[Book-Api] 네이버 도서 정보 조회 작업 완료: isbn={}", isbn);
 
         return new NaverBookDto(
                 item.title(),
@@ -76,10 +84,15 @@ public class NaverBookProvider
      */
     private String toBase64(String imageUrl) {
         if (imageUrl == null || imageUrl.isBlank()) return null;
-
-        try (InputStream is = URI.create(imageUrl).toURL().openStream()) {
-            return Base64.getEncoder().encodeToString(is.readAllBytes());
+        try {
+            URLConnection connection = URI.create(imageUrl).toURL().openConnection();
+            connection.setConnectTimeout(CONNECTION_TIMEOUT_MS);
+            connection.setReadTimeout(READ_TIMEOUT_MS);
+            try (InputStream is = connection.getInputStream()) {
+                return Base64.getEncoder().encodeToString(is.readAllBytes());
+            }
         } catch (Exception e) {
+            log.warn("[Naver-Api] 썸네일 다운로드 작업 실패: url={}, error={}", imageUrl, e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
## 작업 내용
도서 정보 불러오기 시 썸네일 이미지가 표시되지 않던 문제를 해결했습니다.

## 관련 이슈
- closes #38 

## 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 테스트
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료

## 참고 사항
issues를 등록하고 자동으로 close되도록 해봤습니다.

### 스크린샷 (선택)
<img width="1242" height="789" alt="스크린샷 2026-03-08 12 08 54" src="https://github.com/user-attachments/assets/08cbfb8c-7c20-4910-98ab-f7817ea4db57" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 책 검색 이미지 처리 방식이 개선되어 이미지가 인코딩된 형식으로 안정적으로 제공됩니다.
* **Chores**
  * 도서 정보 조회 완료 시 로그가 추가되어 문제 추적과 운영 가시성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->