### PR TITLE
test: 고정된 시간 간격을 사용하여 댓글 목록 조회 테스트 수정

### DIFF
--- a/src/test/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepositoryTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -216,8 +215,12 @@ class CommentRepositoryTest {
     for (int i = 1; i <= 10; i++) {
       Comment comment = commentRepository.save(new Comment(i + "번 댓글", savedReview, savedUser));
 
-      Instant manipulatedTime = baseTime.minus(i, ChronoUnit.MINUTES);
-      ReflectionTestUtils.setField(comment, "createdAt", manipulatedTime);
+      Instant manipulatedTime = baseTime.minus(11L - i, ChronoUnit.MINUTES);
+
+      em.createNativeQuery("UPDATE comments SET created_at = ? WHERE id = ?")
+          .setParameter(1, manipulatedTime)
+          .setParameter(2, comment.getId())
+          .executeUpdate();
     }
 
     commentRepository.flush();


### PR DESCRIPTION
## 작업 내용
> 어떤 작업을 했는지 간략히 설명해주세요.
- 댓글 목록 조회 테스트 시 시간을 강제로 주입하여 항상 일관된 테스트 결과를 갖도록 수정했습니다.

## 관련 이슈

## 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 테스트
- [x] 테스트 코드 작성
- [ ] 로컬 테스트 완료

## 참고 사항
> 리뷰어가 알아야 할 내용이 있다면 작성해주세요.

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **테스트**
  * 댓글 저장소의 커서 기반 페이지네이션 검증을 강화하여 다음 페이지 조회의 일관성 보장
  * 시간 기반 정렬이 포함된 페이지 처리 정확성 확인 로직 보강(게시 시간 조작에 따른 정렬/페이징 검증 포함)
  * 페이징 상태 초기화 후의 결과 일관성 및 특정 항목 내용 검증 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->