### PR TITLE
fix: 유효하지 않은 cursor값 넘어올 경우 에러 처리 추가 및 테스트 코드 수정

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/comment/dto/CommentPageRequest.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/dto/CommentPageRequest.java
@@ -15,7 +15,7 @@ public record CommentPageRequest(
     Integer limit
 ) {
     public CommentPageRequest {
-        if (limit == null || limit <= 0) {
+        if (limit == null) {
             limit = 50;
         }
 

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.redhorse.deokhugam.domain.comment.dto.CommentPageRequest;
 import com.redhorse.deokhugam.domain.comment.entity.Comment;
+import com.redhorse.deokhugam.global.exception.InvalidCursorException;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -50,7 +51,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
           ? comment.createdAt.gt(after).or(comment.createdAt.eq(after).and(comment.id.gt(cursorId)))
           : comment.createdAt.lt(after).or(comment.createdAt.eq(after).and(comment.id.lt(cursorId)));
     } catch (IllegalArgumentException e) {
-      return null;
+      throw new InvalidCursorException("유효하지 않은 커서 형식입니다. " + cursor);
     }
   }
 

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/controller/CommentControllerTest.java
@@ -30,6 +30,7 @@ import com.redhorse.deokhugam.domain.user.exception.UserNotFoundException;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,23 @@ class CommentControllerTest {
   @MockitoBean
   private AlarmService alarmService;
 
+  UUID reviewId;
+  UUID userId;
+  UUID commentId;
+  CommentDto responseDto;
+  UUID requestUserId;
+
+  @BeforeEach
+  void setUp () {
+    reviewId = UUID.randomUUID();
+    userId = UUID.randomUUID();
+    commentId = UUID.randomUUID();
+    requestUserId = UUID.randomUUID();
+
+    responseDto = new CommentDto(commentId, reviewId, userId, "버즈", "컨트롤러 슬라이스 테스트",
+        Instant.now(), Instant.now());
+  }
+
   @Nested
   @DisplayName("댓글 등록 관련 테스트")
   class createCommentsTests {
@@ -65,14 +83,7 @@ class CommentControllerTest {
     @DisplayName("댓글 등록 요청이 성공적으로 처리되어야 한다.")
     void create_Success() throws Exception {
       // given
-      UUID reviewId = UUID.randomUUID();
-      UUID userId = UUID.randomUUID();
-      CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, "하이루");
-
-      CommentDto responseDto = new CommentDto(
-          UUID.randomUUID(), reviewId, userId, "감자", "하이루",
-          Instant.now(), Instant.now()
-      );
+      CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, "컨트롤러 슬라이스 테스트");
 
       given(commentService.create(any(CommentCreateRequest.class))).willReturn(responseDto);
 
@@ -81,8 +92,8 @@ class CommentControllerTest {
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated())
-          .andExpect(jsonPath("$.content").value("하이루"))
-          .andExpect(jsonPath("$.userNickname").value("감자"));
+          .andExpect(jsonPath("$.content").value("컨트롤러 슬라이스 테스트"))
+          .andExpect(jsonPath("$.userNickname").value("버즈"));
 
       verify(alarmService, times(1)).createCommentAlarm(any(CommentDto.class));
     }
@@ -91,13 +102,7 @@ class CommentControllerTest {
     @DisplayName("댓글 등록 성공 - 알림 서비스에서 예외가 발생해도 댓글 생성은 유지되어야 한다.")
     void create_WhenAlarmServiceFails_ShouldStillReturnCreated() throws Exception {
       // given
-      UUID reviewId = UUID.randomUUID();
-      UUID userId = UUID.randomUUID();
-      CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, "알람실패테스트");
-      CommentDto responseDto = new CommentDto(
-          UUID.randomUUID(), reviewId, userId, "감자", "알람실패테스트",
-          Instant.now(), Instant.now()
-      );
+      CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, "컨트롤러 슬라이스 테스트");
 
       given(commentService.create(any(CommentCreateRequest.class))).willReturn(responseDto);
 
@@ -109,7 +114,7 @@ class CommentControllerTest {
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated())
-          .andExpect(jsonPath("$.content").value("알람실패테스트"));
+          .andExpect(jsonPath("$.content").value("컨트롤러 슬라이스 테스트"));
 
       verify(alarmService, times(1)).createCommentAlarm(any(CommentDto.class));
     }
@@ -119,8 +124,7 @@ class CommentControllerTest {
     void create_WhenReviewNotFound_ShouldThrowException() throws Exception {
       // given
       UUID invalidReviewId = UUID.randomUUID();
-      UUID userId = UUID.randomUUID();
-      CommentCreateRequest request = new CommentCreateRequest(invalidReviewId, userId, "하이루");
+      CommentCreateRequest request = new CommentCreateRequest(invalidReviewId, userId, "컨트롤러 슬라이스 테스트");
 
       given(commentService.create(any(CommentCreateRequest.class)))
           .willThrow(new ReviewNotFoundException(invalidReviewId));
@@ -136,10 +140,9 @@ class CommentControllerTest {
     @DisplayName("댓글 등록 실패 - 존재하지 않는 사용자 ID인 경우 404 Not Found를 반환한다.")
     void create_WhenUserNotFound_ShouldThrowException() throws Exception {
       // given
-      UUID reviewId = UUID.randomUUID();
       UUID invalidUserID = UUID.randomUUID();
       CommentCreateRequest request = new CommentCreateRequest(reviewId, invalidUserID,
-          "하이루");
+          "컨트롤러 슬라이스 테스트");
 
       given(commentService.create(any(CommentCreateRequest.class)))
           .willThrow(new UserNotFoundException(invalidUserID));
@@ -173,17 +176,12 @@ class CommentControllerTest {
     @DisplayName("댓글 수정 요청이 성공적으로 처리되어야 한다.")
     void update_Success() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      UUID requestUserId = UUID.randomUUID();
-      CommentUpdateRequest commentReq = new CommentUpdateRequest("댓글 수정 테스트");
-
-      CommentDto responseDto = new CommentDto(
-          commentId, UUID.randomUUID(), requestUserId, "감자", "댓글 수정 테스트",
-          Instant.now(), Instant.now()
-      );
+      CommentUpdateRequest commentReq = new CommentUpdateRequest("컨트롤러 슬라이스 테스트");
+      CommentDto updateResponse = new CommentDto(commentId, reviewId, requestUserId, "버즈",
+          "컨트롤러 슬라이스 테스트", Instant.now(), Instant.now());
 
       given(commentService.update(eq(commentId), eq(requestUserId),
-          any(CommentUpdateRequest.class))).willReturn(responseDto);
+          any(CommentUpdateRequest.class))).willReturn(updateResponse);
 
       // when & then
       mockMvc.perform(patch("/api/comments/{commentId}", commentId)
@@ -192,7 +190,7 @@ class CommentControllerTest {
               .content(objectMapper.writeValueAsString(commentReq)))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.id").value(commentId.toString()))
-          .andExpect(jsonPath("$.content").value("댓글 수정 테스트"))
+          .andExpect(jsonPath("$.content").value("컨트롤러 슬라이스 테스트"))
           .andExpect(jsonPath("$.userId").value(requestUserId.toString()));
     }
 
@@ -200,9 +198,7 @@ class CommentControllerTest {
     @DisplayName("댓글 수정 실패 - 작성자가 아닌 유저가 요청하면 403 Forbidden을 반환한다")
     void update_WhenUserIsNotAuthor_ShouldThrowException() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      UUID requestUserId = UUID.randomUUID();
-      CommentUpdateRequest request = new CommentUpdateRequest("댓글 수정 테스트");
+      CommentUpdateRequest request = new CommentUpdateRequest("컨트롤러 슬라이스 테스트");
 
       given(
           commentService.update(eq(commentId), eq(requestUserId), any(CommentUpdateRequest.class)))
@@ -225,12 +221,6 @@ class CommentControllerTest {
     @DisplayName("댓글 단건 조회 요청이 성공적으로 처리되어야 한다.")
     void find_Success() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      CommentDto responseDto = new CommentDto(
-          commentId, UUID.randomUUID(), UUID.randomUUID(), "감자", "댓글 수정 테스트",
-          Instant.now(), Instant.now()
-      );
-
       given(commentService.find(eq(commentId))).willReturn(responseDto);
 
       // when & then
@@ -265,9 +255,6 @@ class CommentControllerTest {
     @DisplayName("댓글 논리 삭제 요청이 성공적으로 처리되어야 한다.")
     void softDelete_Success() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      UUID requestUserId = UUID.randomUUID();
-
       doNothing().when(commentService).softDelete(eq(commentId), eq(requestUserId));
 
       // when & then
@@ -280,9 +267,6 @@ class CommentControllerTest {
     @DisplayName("댓글 논리 삭제 실패 - 존재하지 않은 댓글 Id인 경우 404 Not Found를 반환한다.")
     void softDelete_WhenCommentNotFound_ShouldThrowException() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      UUID requestUserId = UUID.randomUUID();
-
       doThrow(new CommentNotFoundException(commentId))
           .when(commentService).softDelete(eq(commentId), eq(requestUserId));
 
@@ -296,9 +280,6 @@ class CommentControllerTest {
     @DisplayName("댓글 논리 삭제 실패 - 작성자가 아닌 유저가 요청하면 403 Forbidden을 반환한다.")
     void softDelete_WhenUserIsNotAuthor_ShouldThrowException() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      UUID requestUserId = UUID.randomUUID();
-
       doThrow(new CommentDeleteNotAllowedException(commentId))
           .when(commentService).softDelete(eq(commentId), eq(requestUserId));
 
@@ -311,10 +292,7 @@ class CommentControllerTest {
     @Test
     @DisplayName("댓글 논리 삭제 실패 - 요청 헤더가 누락된 경우 400 Bad Request를 반환한다")
     void softDelete_WhenHeaderMissing_ShouldReturnBadRequest() throws Exception {
-      // given
-      UUID commentId = UUID.randomUUID();
-
-      // when & then
+      // given & when & then
       mockMvc.perform(delete("/api/comments/{commentId}", commentId))
           .andExpect(status().isBadRequest());
     }
@@ -328,9 +306,6 @@ class CommentControllerTest {
     @DisplayName("댓글 물리 삭제 요청이 성공적으로 처리되어야 한다.")
     void hardDelete_Success() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      UUID requestUserId = UUID.randomUUID();
-
       doNothing().when(commentService).hardDelete(eq(commentId), eq(requestUserId));
 
       // when & then
@@ -343,9 +318,6 @@ class CommentControllerTest {
     @DisplayName("댓글 물리 삭제 실패 - 존재하지 않은 댓글 Id인 경우 404 Not Found를 반환한다.")
     void hardDelete_WhenCommentNotFound_ShouldThrowException() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      UUID requestUserId = UUID.randomUUID();
-
       doThrow(new CommentNotFoundException(commentId))
           .when(commentService).hardDelete(eq(commentId), eq(requestUserId));
 
@@ -359,9 +331,6 @@ class CommentControllerTest {
     @DisplayName("댓글 물리 삭제 실패 - 작성자가 아닌 유저가 요청하면 403 Forbidden을 반환한다.")
     void hardDelete_WhenUserIsNotAuthor_ShouldThrowException() throws Exception {
       // given
-      UUID commentId = UUID.randomUUID();
-      UUID requestUserId = UUID.randomUUID();
-
       doThrow(new CommentDeleteNotAllowedException(commentId))
           .when(commentService).hardDelete(eq(commentId), eq(requestUserId));
 
@@ -374,10 +343,7 @@ class CommentControllerTest {
     @Test
     @DisplayName("댓글 물리 삭제 실패 - 요청 헤더가 누락된 경우 400 Bad Request를 반환한다")
     void hardDelete_WhenHeaderMissing_ShouldReturnBadRequest() throws Exception {
-      // given
-      UUID commentId = UUID.randomUUID();
-
-      // when & then
+      // given & when & then
       mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId))
           .andExpect(status().isBadRequest());
     }
@@ -391,7 +357,6 @@ class CommentControllerTest {
     @DisplayName("댓글 목록 조회 요청이 성공적으로 처리되어야 한다.")
     void findAll_Success() throws Exception {
       // given
-      UUID reviewId = UUID.randomUUID();
       CommentPageRequest request = new CommentPageRequest(reviewId, "DESC", null, null, 5);
 
       CursorPageResponseCommentDto responseDto = new CursorPageResponseCommentDto(

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.redhorse.deokhugam.domain.comment.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.redhorse.deokhugam.domain.book.entity.Book;
 import com.redhorse.deokhugam.domain.book.repository.BookRepository;
@@ -11,6 +12,7 @@ import com.redhorse.deokhugam.domain.review.repository.ReviewRepository;
 import com.redhorse.deokhugam.domain.user.entity.User;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
 import com.redhorse.deokhugam.global.config.JpaConfig;
+import com.redhorse.deokhugam.global.exception.InvalidCursorException;
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -176,9 +178,7 @@ class CommentRepositoryTest {
   @DisplayName("댓글 목록 조회 성공(오름차) - 첫 페이지일 경우")
   void findAllByCursor_isAsc_Success() {
     // given
-    for (int i = 1; i <= 10; i++) {
-      commentRepository.save(new Comment(i + "번 댓글", savedReview, savedUser));
-    }
+    setupCommentsWithTimeGap();
     CommentPageRequest request = new CommentPageRequest(savedReview.getId(), "ASC", null, null, 5);
 
     // when
@@ -190,12 +190,10 @@ class CommentRepositoryTest {
   }
 
   @Test
-  @DisplayName("댓글 목록 조회 성공 - 첫 페이지일 경우")
+  @DisplayName("댓글 목록 조회 성공(내림차) - 첫 페이지일 경우")
   void findAllByCursor_FirstPage_Success() {
     // given
-    for (int i = 1; i <= 10; i++) {
-      commentRepository.save(new Comment(i + "번 댓글", savedReview, savedUser));
-    }
+    setupCommentsWithTimeGap();
     CommentPageRequest request = new CommentPageRequest(savedReview.getId(), null, null, null, 5);
 
     // when
@@ -209,22 +207,8 @@ class CommentRepositoryTest {
   @Test
   @DisplayName("댓글 목록 조회 성공 - 다음 페이지일 경우")
   void findAllByCursor_NextPage_Success() {
-    // given : 10개의 댓글을 저장하고 시간을 1분씩 과거로 강제 설정
-    Instant baseTime = Instant.now().truncatedTo(ChronoUnit.MICROS);
-
-    for (int i = 1; i <= 10; i++) {
-      Comment comment = commentRepository.save(new Comment(i + "번 댓글", savedReview, savedUser));
-
-      Instant manipulatedTime = baseTime.minus(11L - i, ChronoUnit.MINUTES);
-
-      em.createNativeQuery("UPDATE comments SET created_at = ? WHERE id = ?")
-          .setParameter(1, manipulatedTime)
-          .setParameter(2, comment.getId())
-          .executeUpdate();
-    }
-
-    commentRepository.flush();
-    em.clear();
+    // given
+    setupCommentsWithTimeGap();
 
     CommentPageRequest firstRequest = new CommentPageRequest(savedReview.getId(), null, null, null, 5);
     List<Comment> result = commentRepository.findAllByCursor(firstRequest);
@@ -239,25 +223,6 @@ class CommentRepositoryTest {
     assertThat(nextResult).isNotEmpty();
     assertThat(nextResult.get(0).getId()).isNotEqualTo(lastComment.getId());
     assertThat(nextResult.get(0).getContent()).isEqualTo("5번 댓글");
-  }
-
-  @Test
-  @DisplayName("댓글 목록 조회 성공 - 잘못된 형식의 UUID 커서가 넘어온 경우")
-  void findAllByCursor_InvalidUUID_ReturnFirstPage() {
-    // given
-    for (int i = 1; i <= 5; i++) {
-      commentRepository.save(new Comment(i + "번 댓글", savedReview, savedUser));
-    }
-
-    // 커서 역할을 못하기 때문에 다음 페이지 조회 x
-    CommentPageRequest request = new CommentPageRequest(savedReview.getId(), null, "invalid-uuid", Instant.now(), 5);
-
-    // when
-    List<Comment> result = commentRepository.findAllByCursor(request);
-
-    // then
-    assertThat(result).hasSize(5);
-    assertThat(result.get(0).getContent()).isEqualTo("5번 댓글"); // 최신순 첫 페이지 데이터
   }
 
   @Test
@@ -277,5 +242,35 @@ class CommentRepositoryTest {
     // then
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getContent()).isEqualTo("살아있는 댓글");
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 실패 - 잘못된 형식의 UUID 커서가 넘어온 경우")
+  void findAllByCursor_InvalidUUID_ShouldThrowException() {
+    // given
+    commentRepository.save(new Comment("테스트 댓글", savedReview, savedUser));
+
+    // 커서 역할을 못하기 때문에 다음 페이지 조회 x
+    CommentPageRequest request = new CommentPageRequest(savedReview.getId(), null, "invalid-uuid", Instant.now(), 5);
+
+    // when
+    assertThatThrownBy(() -> commentRepository.findAllByCursor(request))
+        .isInstanceOf(InvalidCursorException.class);
+  }
+
+  private void setupCommentsWithTimeGap() {
+    Instant baseTime = Instant.now().truncatedTo(ChronoUnit.MICROS);
+    for (int i = 1; i <= 10; i++) {
+      Comment comment = commentRepository.save(new Comment(i + "번 댓글", savedReview, savedUser));
+
+      Instant manipulatedTime = baseTime.minus(10L - i, ChronoUnit.MINUTES);
+
+      em.createNativeQuery("UPDATE comments SET created_at = ? WHERE id = ?")
+          .setParameter(1, manipulatedTime)
+          .setParameter(2, comment.getId())
+          .executeUpdate();
+    }
+    commentRepository.flush();
+    em.clear();
   }
 }


### PR DESCRIPTION
## 작업 내용
> 어떤 작업을 했는지 간략히 설명해주세요.
- 잘못된 cursor UUID 전달 시 오류 발생하도록 추가했습니다.
- 그에 따른 테스트 코드 수정했습니다.
- CommentRepository에서 댓글의 시간을 강제 주입하는 공통 메서드를 추출하여 댓글 목록 조회 테스트에서 호출하도록 수정했습니다.
- CommentController 테스트는 공통 코드를 setUP으로 추출하여 리팩토링하는 작업 진행했습니다. (424줄 -> 390줄)
## 관련 이슈
- closes #이슈번호

## 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 기타

## 테스트
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료

## 참고 사항
> 리뷰어가 알아야 할 내용이 있다면 작성해주세요.

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 댓글 조회 시 잘못된 커서 값에 대한 예외 처리 개선

## 테스트
* 댓글 컨트롤러 및 저장소 테스트 코드 구조 개선
* 테스트 픽스처 중앙화로 코드 중복 감소 및 유지보수성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->