### PR TITLE
refactor: Test할때 Test환경 제거

### DIFF
--- a/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/user/controller/UserControllerTest.java
@@ -32,13 +32,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserController.class)
 @DisplayName("UserController 슬라이스 테스트")
-@ActiveProfiles("test")
 class UserControllerTest {
 
   @Autowired
@@ -383,8 +381,8 @@ class UserControllerTest {
     var result = mockMvc.perform(delete("/api/users/{userId}", userId));
 
     // then
-    result.andExpect(status().isBadRequest());
-    result.andExpect(jsonPath("$.message").value("필수 헤더가 누락되었습니다: Deokhugam-Request-User-ID"));
+    result.andExpect(status().isUnauthorized());
+    result.andExpect(jsonPath("$.message").value("인증에 실패하였습니다."));
   }
 
   @Test
@@ -493,8 +491,8 @@ class UserControllerTest {
     var result = mockMvc.perform(delete("/api/users/{userId}/hard", userId));
 
     // then
-    result.andExpect(status().isBadRequest());
-    result.andExpect(jsonPath("$.message").value("필수 헤더가 누락되었습니다: Deokhugam-Request-User-ID"));
+    result.andExpect(status().isUnauthorized());
+    result.andExpect(jsonPath("$.message").value("인증에 실패하였습니다."));
   }
 
 }


### PR DESCRIPTION
## 작업 내용
- Test환경에서 돌던 Test코드를 일반 환경에서 돌도록 수정
- 헤더 에러문구 변경된 것 반영

## 관련 이슈


## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [X] 리팩토링
- [ ] 기타

## 테스트
- [X] 테스트 코드 작성
- [X] 로컬 테스트 완료

## 참고 사항

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 정보

* **버그 수정**
  * 인증 헤더 검증 실패 시 응답 상태 코드를 401로 통일하고 오류 메시지를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->