### PR TITLE
feat: 로그 업로드 실패 시 재시도 로직 추가

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/infra/s3/scheduler/LogUploadScheduler.java
+++ b/src/main/java/com/redhorse/deokhugam/infra/s3/scheduler/LogUploadScheduler.java
@@ -38,9 +38,13 @@ public class LogUploadScheduler
      */
     @Scheduled(cron = "0 0 1 * * *")
     // @Scheduled(cron = "0 * * * * *")
-    public void uploadLog() throws IOException {
+    public void uploadLog() {
         // 1. 이전 실패 목록 재시도
-        retryFailedUploads();
+        try {
+            retryFailedUploads();
+        } catch (IOException e) {
+            log.error("[Log-Scheduler] 실패 목록 재시도 작업 실패: ", e);
+        }
 
         // 2. 전날 로그 업로드
         String yesterday = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
@@ -50,7 +54,7 @@ public class LogUploadScheduler
             files.filter(path -> path.getFileName().toString().contains(yesterday))
                     .forEach(this::uploadWithFailureChecking);
         } catch (IOException e) {
-            log.error("[Scheduler] 로그 파일 업로드 작업 실패: {}", e.getMessage());
+            log.error("[Log-Scheduler] 로그 파일 업로드 작업 실패: {}", e.getMessage());
         }
     }
 
@@ -76,9 +80,11 @@ public class LogUploadScheduler
         for (String pathStr : failedPaths) {
             try {
                 s3LogStorage.upload(Paths.get(pathStr));
-                log.info("[Scheduler] 재업로드 성공: path={}", pathStr);
+                stillFailed.remove(pathStr);
+                Files.write(failedFile, stillFailed);
+                log.info("[Log-Scheduler] 재업로드 성공: path={}", pathStr);
             } catch (S3UploadException e) {
-                log.error("[Scheduler] 재업로드 실패: path={}", pathStr);
+                log.error("[Log-Scheduler] 재업로드 실패: path={}", pathStr);
                 stillFailed.add(pathStr);  // 실패한 것만 유지
             }
         }


### PR DESCRIPTION
## 작업 내용
S3 로그 업로드 실패 시 서버 재시작에도 유실되지 않도록 실패 목록을 저장하고 다음 스케줄러 실행 시 재시도합니다.
- 서버 재시작 후에도 failed_uploads.txt가 유지되어 로그 유실 방지
- 동일한 파일이 중복 업로드되지 않도록 성공한 경로는 즉시 제거

## 관련 이슈
- #107 

## 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 테스트
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료

## 참고 사항

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 실패한 로그 업로드 시 해당 경로를 기록하고 이후 자동 재시도하여 업로드 신뢰성 향상
  * 재시도 시도 결과(성공/실패)를 기록하여 문제 추적성 개선

* **새 기능**
  * 영속적인 실패 추적 저장소를 도입해 재시도 대상 관리 및 데이터 손실 위험 감소
<!-- end of auto-generated comment: release notes by coderabbit.ai -->