### PR TITLE
fix: 리뷰, 도서, 댓글 간 캐시 무효화 수정

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -1,10 +1,6 @@
 package com.redhorse.deokhugam.domain.comment.service;
 
-import com.redhorse.deokhugam.domain.comment.dto.CommentCreateRequest;
-import com.redhorse.deokhugam.domain.comment.dto.CommentDto;
-import com.redhorse.deokhugam.domain.comment.dto.CommentPageRequest;
-import com.redhorse.deokhugam.domain.comment.dto.CommentUpdateRequest;
-import com.redhorse.deokhugam.domain.comment.dto.CursorPageResponseCommentDto;
+import com.redhorse.deokhugam.domain.comment.dto.*;
 import com.redhorse.deokhugam.domain.comment.entity.Comment;
 import com.redhorse.deokhugam.domain.comment.exception.CommentDeleteNotAllowedException;
 import com.redhorse.deokhugam.domain.comment.exception.CommentNotFoundException;
@@ -17,13 +13,17 @@ import com.redhorse.deokhugam.domain.review.repository.ReviewRepository;
 import com.redhorse.deokhugam.domain.user.entity.User;
 import com.redhorse.deokhugam.domain.user.exception.UserNotFoundException;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,13 +36,17 @@ public class CommentServiceImpl implements CommentService {
   private final CommentRepository commentRepository;
   private final CommentMapper commentMapper;
 
+  @Caching(evict = {
+          @CacheEvict(value = "review", key = "#commentCreateRequest.reviewId()"),
+          @CacheEvict(value = "comment", key = "#commentCreateRequest.reviewId()")
+  })
   @Override
   public CommentDto create(CommentCreateRequest commentCreateRequest) {
     UUID reviewId = commentCreateRequest.reviewId();
     UUID userId = commentCreateRequest.userId();
     String content = commentCreateRequest.content();
 
-    Review review = reviewRepository.findByIdAndDeletedAtIsNull(reviewId)
+    Review review = reviewRepository.findByIdForUpdate(reviewId)
         .orElseThrow(() -> new ReviewNotFoundException(reviewId));
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
@@ -57,6 +61,7 @@ public class CommentServiceImpl implements CommentService {
     return commentMapper.toDto(savedComment);
   }
 
+  @CacheEvict(value = "comment", key = "#commentId")
   @Override
   public CommentDto update(UUID commentId, UUID requestUserId,
       CommentUpdateRequest commentUpdateRequest) {
@@ -76,6 +81,7 @@ public class CommentServiceImpl implements CommentService {
     return commentMapper.toDto(comment);
   }
 
+  @Cacheable(value = "comment", key = "#commentId")
   @Override
   @Transactional(readOnly = true)
   public CommentDto find(UUID commentId) {
@@ -84,11 +90,13 @@ public class CommentServiceImpl implements CommentService {
 
     log.debug("[Comment-Service] 단건 조회 작업 완료: commentId={}", commentId);
 
-    log.debug("[Comment-Service] 단건 조회 작업 완료: commentId={}", commentId);
-
     return commentMapper.toDto(comment);
   }
 
+  @Caching(evict = {
+          @CacheEvict(value = "comment", key = "#commentId"),
+          @CacheEvict(value = "review", allEntries = true)
+  })
   @Override
   public void softDelete(UUID commentId, UUID requestUserId) {
     validateRequestUser(requestUserId);
@@ -106,6 +114,10 @@ public class CommentServiceImpl implements CommentService {
     log.info("[Comment-Service] 논리 삭제 작업 완료: commentId={}", commentId);
   }
 
+  @Caching(evict = {
+          @CacheEvict(value = "comment", key = "#commentId"),
+          @CacheEvict(value = "review", allEntries = true)
+  })
   @Override
   public void hardDelete(UUID commentId, UUID requestUserId) {
     validateRequestUser(requestUserId);

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -15,6 +15,7 @@ import com.redhorse.deokhugam.domain.user.exception.UserNotFoundException;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -35,10 +37,10 @@ public class CommentServiceImpl implements CommentService {
   private final UserRepository userRepository;
   private final CommentRepository commentRepository;
   private final CommentMapper commentMapper;
+  private final CacheManager cacheManager;
 
   @Caching(evict = {
-          @CacheEvict(value = "review", key = "#commentCreateRequest.reviewId()"),
-          @CacheEvict(value = "comment", key = "#commentCreateRequest.reviewId()")
+          @CacheEvict(value = "review", key = "#commentCreateRequest.reviewId()")
   })
   @Override
   public CommentDto create(CommentCreateRequest commentCreateRequest) {
@@ -94,8 +96,7 @@ public class CommentServiceImpl implements CommentService {
   }
 
   @Caching(evict = {
-          @CacheEvict(value = "comment", key = "#commentId"),
-          @CacheEvict(value = "review", allEntries = true)
+          @CacheEvict(value = "comment", key = "#commentId")
   })
   @Override
   public void softDelete(UUID commentId, UUID requestUserId) {
@@ -111,12 +112,15 @@ public class CommentServiceImpl implements CommentService {
     comment.softDelete();
     Review review = comment.getReview();
     review.decrementCommentCount();
+
+    Optional.ofNullable(cacheManager.getCache("review"))
+                    .ifPresent(cache -> cache.evict(review.getId()));
+
     log.info("[Comment-Service] 논리 삭제 작업 완료: commentId={}", commentId);
   }
 
   @Caching(evict = {
-          @CacheEvict(value = "comment", key = "#commentId"),
-          @CacheEvict(value = "review", allEntries = true)
+          @CacheEvict(value = "comment", key = "#commentId")
   })
   @Override
   public void hardDelete(UUID commentId, UUID requestUserId) {
@@ -129,6 +133,9 @@ public class CommentServiceImpl implements CommentService {
     if (!comment.getUser().getId().equals(requestUserId)) {
       throw new CommentDeleteNotAllowedException(commentId);
     }
+
+    Optional.ofNullable(cacheManager.getCache("review"))
+                    .ifPresent(cache -> cache.evict(comment.getReview().getId()));
 
     commentRepository.delete(comment);
 

--- a/src/main/java/com/redhorse/deokhugam/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/review/service/ReviewServiceImpl.java
@@ -94,7 +94,8 @@ public class ReviewServiceImpl implements ReviewService {
     Double newRating = reviewRepository.averageRatingByBookId(review.getBook().getId());
     review.getBook().updateRating(newRating != null ? newRating : 0.0);
 
-    cacheManager.getCache("book").evict(review.getBook().getId());
+    Optional.ofNullable(cacheManager.getCache("book"))
+                    .ifPresent(cache -> cache.evict(review.getBook().getId()));
 
     log.info("[Review-Service] 수정 작업 완료: reviewId = {}, userID = {}", reviewId, userId);
 
@@ -114,7 +115,8 @@ public class ReviewServiceImpl implements ReviewService {
     Double newRating = reviewRepository.averageRatingByBookId(review.getBook().getId());
     review.getBook().updateReviewsStats(newReviewCount, newRating != null ? newRating : 0.0);
 
-    cacheManager.getCache("book").evict(review.getBook().getId());
+    Optional.ofNullable(cacheManager.getCache("book"))
+            .ifPresent(cache -> cache.evict(review.getBook().getId()));
 
     log.info("[Review-Service] 논리 삭제 작업 완료: reviewId = {}", reviewId);
   }

--- a/src/main/java/com/redhorse/deokhugam/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/review/service/ReviewServiceImpl.java
@@ -3,12 +3,7 @@ package com.redhorse.deokhugam.domain.review.service;
 import com.redhorse.deokhugam.domain.book.entity.Book;
 import com.redhorse.deokhugam.domain.book.exception.BookNotFoundException;
 import com.redhorse.deokhugam.domain.book.repository.BookRepository;
-import com.redhorse.deokhugam.domain.review.dto.CursorPageResponseReviewDto;
-import com.redhorse.deokhugam.domain.review.dto.ReviewCreateRequest;
-import com.redhorse.deokhugam.domain.review.dto.ReviewDto;
-import com.redhorse.deokhugam.domain.review.dto.ReviewLikeDto;
-import com.redhorse.deokhugam.domain.review.dto.ReviewSearchRequest;
-import com.redhorse.deokhugam.domain.review.dto.ReviewUpdateRequest;
+import com.redhorse.deokhugam.domain.review.dto.*;
 import com.redhorse.deokhugam.domain.review.entity.Review;
 import com.redhorse.deokhugam.domain.review.entity.ReviewLike;
 import com.redhorse.deokhugam.domain.review.exception.BookIdUserIdExistsException;
@@ -21,21 +16,18 @@ import com.redhorse.deokhugam.domain.review.repository.ReviewRepository;
 import com.redhorse.deokhugam.domain.user.entity.User;
 import com.redhorse.deokhugam.domain.user.exception.UserNotFoundException;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -47,7 +39,9 @@ public class ReviewServiceImpl implements ReviewService {
   private final UserRepository userRepository;
   private final BookRepository bookRepository;
   private final ReviewMapper reviewMapper;
+  private final CacheManager cacheManager;
 
+  @CacheEvict(value = "book", key = "#request.bookId")
   @Transactional
   @Override
   public ReviewDto create(ReviewCreateRequest request) {
@@ -77,7 +71,7 @@ public class ReviewServiceImpl implements ReviewService {
 
   }
 
-  @Caching(evict = {@CacheEvict(value = "review", key = "#reviewId")})
+  @CacheEvict(value = "review", key = "#reviewId")
   @Transactional
   @Override
   public ReviewDto update(UUID reviewId, UUID userId, ReviewUpdateRequest request) {
@@ -100,6 +94,8 @@ public class ReviewServiceImpl implements ReviewService {
     Double newRating = reviewRepository.averageRatingByBookId(review.getBook().getId());
     review.getBook().updateRating(newRating != null ? newRating : 0.0);
 
+    cacheManager.getCache("book").evict(review.getBook().getId());
+
     log.info("[Review-Service] 수정 작업 완료: reviewId = {}, userID = {}", reviewId, userId);
 
     return reviewMapper.toDto(review);
@@ -117,6 +113,8 @@ public class ReviewServiceImpl implements ReviewService {
     long newReviewCount = reviewRepository.countByBookId(review.getBook().getId());
     Double newRating = reviewRepository.averageRatingByBookId(review.getBook().getId());
     review.getBook().updateReviewsStats(newReviewCount, newRating != null ? newRating : 0.0);
+
+    cacheManager.getCache("book").evict(review.getBook().getId());
 
     log.info("[Review-Service] 논리 삭제 작업 완료: reviewId = {}", reviewId);
   }

--- a/src/main/java/com/redhorse/deokhugam/global/config/CaffeineConfig.java
+++ b/src/main/java/com/redhorse/deokhugam/global/config/CaffeineConfig.java
@@ -38,23 +38,19 @@ public class CaffeineConfig {
                                 .expireAfterWrite(24, TimeUnit.HOURS)
                                 .maximumSize(500)
                                 .recordStats()
-                                .build()
-                ),
-
+                                .build()),
                 new CaffeineCache("popularReviews",
                         Caffeine.newBuilder()
                                 .expireAfterWrite(24, TimeUnit.HOURS)
                                 .maximumSize(500)
                                 .recordStats()
                                 .build()),
-
                 new CaffeineCache("powerUsers",
                         Caffeine.newBuilder()
                                 .expireAfterWrite(24, TimeUnit.HOURS)
                                 .maximumSize(500)
                                 .recordStats()
                                 .build()),
-
                 new CaffeineCache("popularBooks",
                         Caffeine.newBuilder()
                                 .expireAfterWrite(24, TimeUnit.HOURS)
@@ -66,7 +62,13 @@ public class CaffeineConfig {
                                .expireAfterWrite(1, TimeUnit.HOURS)
                                .maximumSize(1000)
                                .recordStats()
-                               .build())
+                               .build()),
+                new CaffeineCache("comment",
+                        Caffeine.newBuilder()
+                                .expireAfterWrite(10, TimeUnit.HOURS)
+                                .maximumSize(2000)
+                                .recordStats()
+                                .build())
         ));
 
         return cacheManager;

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
@@ -1,16 +1,5 @@
 package com.redhorse.deokhugam.domain.comment.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import com.redhorse.deokhugam.domain.comment.dto.CommentCreateRequest;
 import com.redhorse.deokhugam.domain.comment.dto.CommentDto;
 import com.redhorse.deokhugam.domain.comment.dto.CommentPageRequest;
@@ -27,11 +16,6 @@ import com.redhorse.deokhugam.domain.review.repository.ReviewRepository;
 import com.redhorse.deokhugam.domain.user.entity.User;
 import com.redhorse.deokhugam.domain.user.exception.UserNotFoundException;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +23,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -77,7 +74,7 @@ class CommentServiceTest {
       Review mockReview = mock(Review.class);
       User mockUser = mock(User.class);
 
-      given(reviewRepository.findByIdAndDeletedAtIsNull(eq(reviewId))).willReturn(
+      given(reviewRepository.findByIdForUpdate(eq(reviewId))).willReturn(
           Optional.of(mockReview));
       given(userRepository.findById(eq(userId))).willReturn(Optional.of(mockUser));
       given(mockUser.getNickname()).willReturn("감자");
@@ -106,7 +103,7 @@ class CommentServiceTest {
       UUID userId = UUID.randomUUID();
       CommentCreateRequest commentReq = new CommentCreateRequest(invalidReviewId, userId, "하이");
 
-      given(reviewRepository.findByIdAndDeletedAtIsNull(eq(invalidReviewId))).willReturn(
+      given(reviewRepository.findByIdForUpdate(eq(invalidReviewId))).willReturn(
           Optional.empty());
 
       // when & then
@@ -126,7 +123,7 @@ class CommentServiceTest {
       CommentCreateRequest commentReq = new CommentCreateRequest(reviewId, invalidUserId, "하이");
 
       Review mockReview = mock(Review.class);
-      given(reviewRepository.findByIdAndDeletedAtIsNull(eq(reviewId))).willReturn(
+      given(reviewRepository.findByIdForUpdate(eq(reviewId))).willReturn(
           Optional.of(mockReview));
       given(userRepository.findById(eq(invalidUserId))).willReturn(Optional.empty());
 

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -51,6 +53,9 @@ class CommentServiceTest {
 
   @Mock
   private CommentMapper commentMapper;
+
+  @Mock
+  private CacheManager cacheManager;
 
   @InjectMocks
   private CommentServiceImpl commentService;
@@ -277,7 +282,10 @@ class CommentServiceTest {
       given(commentRepository.findByIdAndDeletedAtIsNull(eq(commentId))).willReturn(
           Optional.of(mockComment));
 
-      // when
+      Cache cache = mock(Cache.class);
+      given(cacheManager.getCache("review")).willReturn(cache);
+
+        // when
       commentService.softDelete(commentId, requestUserId);
 
       // then
@@ -361,6 +369,12 @@ class CommentServiceTest {
       Comment mockComment = mock(Comment.class);
       given(mockComment.getUser()).willReturn(mockUser);
       given(commentRepository.findById(eq(commentId))).willReturn(Optional.of(mockComment));
+
+      Review mockReview = mock(Review.class);
+      given(mockComment.getReview()).willReturn(mockReview);
+
+      Cache cache = mock(Cache.class);
+      given(cacheManager.getCache("review")).willReturn(cache);
 
       // when
       commentService.hardDelete(commentId, requestUserId);

--- a/src/test/java/com/redhorse/deokhugam/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/review/service/ReviewServiceTest.java
@@ -1,13 +1,5 @@
 package com.redhorse.deokhugam.domain.review.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
 import com.redhorse.deokhugam.domain.book.entity.Book;
 import com.redhorse.deokhugam.domain.book.exception.BookNotFoundException;
 import com.redhorse.deokhugam.domain.book.repository.BookRepository;
@@ -26,11 +18,6 @@ import com.redhorse.deokhugam.domain.review.repository.ReviewRepository;
 import com.redhorse.deokhugam.domain.user.entity.User;
 import com.redhorse.deokhugam.domain.user.exception.UserNotFoundException;
 import com.redhorse.deokhugam.domain.user.repository.UserRepository;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,7 +25,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class ReviewServiceTest {
@@ -60,6 +63,9 @@ public class ReviewServiceTest {
 
   @InjectMocks
   private ReviewServiceImpl reviewService;
+
+  @Mock
+  private CacheManager cacheManager;
 
   private UUID reviewId;
   private UUID bookId;
@@ -181,6 +187,9 @@ public class ReviewServiceTest {
     );
     given(reviewMapper.toDto(any(Review.class))).willReturn(updateReviewDto);
 
+    Cache cache = mock(Cache.class);
+    given(cacheManager.getCache("book")).willReturn(cache);
+
     // when
     ReviewDto result = reviewService.update(reviewId, userId, request);
 
@@ -225,6 +234,9 @@ public class ReviewServiceTest {
     // given
     given(reviewRepository.findByIdForUpdate(eq(reviewId)))
         .willReturn(Optional.of(review));
+
+    Cache cache = mock(Cache.class);
+    given(cacheManager.getCache("book")).willReturn(cache);
 
     // when
     reviewService.softDelete(reviewId, userId);


### PR DESCRIPTION
## 작업 내용
- 댓글에 캐싱을 적용했습니다.
- 리뷰, 도서, 댓글 간 캐시가 무효화 되는 문제를 수정했습니다.

## 관련 이슈
- 

## 변경 사항
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 테스트
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료

## 참고 사항

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 댓글과 리뷰 조회 성능을 위한 캐시 도입 및 강화: 댓글 전용 캐시 추가, 리뷰 캐시 설정 조정.
  * 생성·수정·소프트/하드 삭제 시 관련 댓글·리뷰 캐시를 명시적 무효화해 데이터 일관성 향상.
* **테스트**
  * 캐시 동작을 모의하는 테스트를 추가·조정하여 캐시 무효화 및 상호작용을 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->