### PR TITLE
fix: rds 저장시간(표준시)과 불러오는 시간(한국시) 차로 인한 불러오기 실패를 수정

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/alarm/exception/AlarmAccessDeniedException.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/alarm/exception/AlarmAccessDeniedException.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public class AlarmAccessDeniedException extends AlarmException {
     public AlarmAccessDeniedException(UUID alarmId) {
-        super(ErrorCode.AlarmAccessDeniedException, Map.of("alarm", alarmId));
+        super(ErrorCode.ALARM_ACCES_DENIED, Map.of("alarm", alarmId));
     }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/alarm/exception/AlarmAccessDeniedException.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/alarm/exception/AlarmAccessDeniedException.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public class AlarmAccessDeniedException extends AlarmException {
     public AlarmAccessDeniedException(UUID alarmId) {
-        super(ErrorCode.ALARM_ACCES_DENIED, Map.of("alarm", alarmId));
+        super(ErrorCode.ALARM_ACCESS_DENIED, Map.of("alarm", alarmId));
     }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> {
-
     @Query("SELECT a FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
             "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
@@ -20,4 +19,9 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
             @Param("request") DashboardRequest request,
             @Param("yesterday") LocalDate yesterday,
             Pageable pageable);
+
+    @Query("SELECT COUNT(a) FROM PopularReview a " +
+            "WHERE a.period = :#{#request.period} " +
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Long countByRequestAndDate(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
@@ -14,7 +14,6 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
 
     @Query("SELECT a FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE " +
-            "ORDER BY a.ranking DESC")
+            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE")
     Slice<PopularBook> getAllPopularBook(@Param("request") DashboardRequest request, Pageable pageable);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
@@ -20,7 +20,7 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
             @Param("yesterday") LocalDate yesterday,
             Pageable pageable);
 
-    @Query("SELECT COUNT(a) FROM PopularReview a " +
+    @Query("SELECT COUNT(a) FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
             "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
     Long countByRequestAndDate(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
@@ -8,12 +8,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> {
 
     @Query("SELECT a FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE")
-    Slice<PopularBook> getAllPopularBook(@Param("request") DashboardRequest request, Pageable pageable);
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Slice<PopularBook> getAllPopularBook(
+            @Param("request") DashboardRequest request,
+            @Param("yesterday") LocalDate yesterday,
+            Pageable pageable);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
@@ -24,6 +24,6 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
 
     @Query("SELECT COUNT(a) FROM PopularReview a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE")
-    Long countByRequest(@Param("request") DashboardRequest request);
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Long countByRequest(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
@@ -8,14 +8,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public interface PopularReviewRepository extends JpaRepository<PopularReview, UUID> {
 
     @Query("SELECT a FROM PopularReview a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE ")
-    Slice<PopularReview> getAllPopularReview(@Param("request") DashboardRequest request, Pageable pageable);
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Slice<PopularReview> getAllPopularReview(
+            @Param("request") DashboardRequest request,
+            @Param("yesterday") LocalDate yesterday,
+            Pageable pageable);
 
 
     @Query("SELECT COUNT(a) FROM PopularReview a " +

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
@@ -14,8 +14,7 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
 
     @Query("SELECT a FROM PopularReview a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE " +
-            "ORDER BY a.ranking DESC")
+            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE ")
     Slice<PopularReview> getAllPopularReview(@Param("request") DashboardRequest request, Pageable pageable);
 
 

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
@@ -20,4 +20,9 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
             @Param("request") DashboardRequest request,
             @Param("yesterday") LocalDate yesterday,
             Pageable pageable);
+
+    @Query("SELECT COUNT(a) FROM PopularReview a " +
+            "WHERE a.period = :#{#request.period} " +
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Long countByRequestAndDate(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
@@ -14,7 +14,6 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
 
     @Query("SELECT a FROM PowerUser a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE " +
-            "ORDER BY a.ranking DESC")
+            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE ")
     Slice<PowerUser> getAllPowerUser(@Param("request") DashboardRequest request, Pageable pageable);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
@@ -21,7 +21,7 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
             @Param("yesterday") LocalDate yesterday,
             Pageable pageable);
 
-    @Query("SELECT COUNT(a) FROM PopularReview a " +
+    @Query("SELECT COUNT(a) FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
             "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
     Long countByRequestAndDate(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
@@ -8,12 +8,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
 
     @Query("SELECT a FROM PowerUser a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE ")
-    Slice<PowerUser> getAllPowerUser(@Param("request") DashboardRequest request, Pageable pageable);
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Slice<PowerUser> getAllPowerUser(
+            @Param("request") DashboardRequest request,
+            @Param("yesterday") LocalDate yesterday,
+            Pageable pageable);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -44,8 +45,9 @@ public class DashboardServiceImpl implements DashboardService {
         Sort sort = Sort.by(direction, "ranking");
 
         Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
+        LocalDate yesterday = LocalDate.now().minusDays(1);
 
-        Slice<PopularReview> slice = reviewRepository.getAllPopularReview(request, pageable);
+        Slice<PopularReview> slice = reviewRepository.getAllPopularReview(request, yesterday, pageable);
         List<PopularReview> objectList = slice.getContent();
         Long objectCount = reviewRepository.countByRequest(request);
 
@@ -83,7 +85,8 @@ public class DashboardServiceImpl implements DashboardService {
         Sort sort = Sort.by(direction, "ranking");
 
         Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
-        Slice<PowerUser> slice = userRepository.getAllPowerUser(request, pageable);
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        Slice<PowerUser> slice = userRepository.getAllPowerUser(request,yesterday, pageable);
         List<PowerUser> objectList = slice.getContent();
         Long objectCount = userRepository.count();
 
@@ -120,8 +123,9 @@ public class DashboardServiceImpl implements DashboardService {
         Sort sort = Sort.by(direction, "ranking");
 
         Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
+        LocalDate yesterday = LocalDate.now().minusDays(1);
 
-        Slice<PopularBook> slice = bookRepository.getAllPopularBook(request, pageable);
+        Slice<PopularBook> slice = bookRepository.getAllPopularBook(request,yesterday, pageable);
         List<PopularBook> objectList = slice.getContent();
         Long objectCount = bookRepository.count();
 

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
@@ -49,7 +49,7 @@ public class DashboardServiceImpl implements DashboardService {
 
         Slice<PopularReview> slice = reviewRepository.getAllPopularReview(request, yesterday, pageable);
         List<PopularReview> objectList = slice.getContent();
-        Long objectCount = reviewRepository.countByRequest(request);
+        Long objectCount = reviewRepository.countByRequest(request,yesterday);
 
         String nextCursor = null;
         Instant nextAfter = null;
@@ -88,7 +88,7 @@ public class DashboardServiceImpl implements DashboardService {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         Slice<PowerUser> slice = userRepository.getAllPowerUser(request,yesterday, pageable);
         List<PowerUser> objectList = slice.getContent();
-        Long objectCount = userRepository.count();
+        Long objectCount = userRepository.countByRequestAndDate(request, yesterday);
 
         String nextCursor = null;
         Instant nextAfter = null;
@@ -127,7 +127,7 @@ public class DashboardServiceImpl implements DashboardService {
 
         Slice<PopularBook> slice = bookRepository.getAllPopularBook(request,yesterday, pageable);
         List<PopularBook> objectList = slice.getContent();
-        Long objectCount = bookRepository.count();
+        Long objectCount = bookRepository.countByRequestAndDate(request, yesterday);
 
         String nextCursor = null;
         Instant nextAfter = null;

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
@@ -40,7 +40,11 @@ public class DashboardServiceImpl implements DashboardService {
     @Cacheable(value = "popularReviews", key = "#request") // DTO가 record 타입이면 DTO자체를 키로 설정 가능
     public CursorPageResponsePopularReviewkDto getPopularReviews(DashboardRequest request) {
 
-        Pageable pageable = PageRequest.of(0, request.limit() + 1);
+        Sort.Direction direction = Sort.Direction.fromString(request.direction());
+        Sort sort = Sort.by(direction, "ranking");
+
+        Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
+
         Slice<PopularReview> slice = reviewRepository.getAllPopularReview(request, pageable);
         List<PopularReview> objectList = slice.getContent();
         Long objectCount = reviewRepository.countByRequest(request);
@@ -75,7 +79,10 @@ public class DashboardServiceImpl implements DashboardService {
     @Cacheable(value = "powerUsers", key = "#request")
     public CursorPageResponsePowerUserDto getPowerUsers(DashboardRequest request) {
 
-        Pageable pageable = PageRequest.of(0, request.limit() + 1);
+        Sort.Direction direction = Sort.Direction.fromString(request.direction());
+        Sort sort = Sort.by(direction, "ranking");
+
+        Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
         Slice<PowerUser> slice = userRepository.getAllPowerUser(request, pageable);
         List<PowerUser> objectList = slice.getContent();
         Long objectCount = userRepository.count();
@@ -109,7 +116,11 @@ public class DashboardServiceImpl implements DashboardService {
     @Cacheable(value = "popularBooks", key = "#request")
     public CursorPageResponsePopularBookDto getPopularBooks(DashboardRequest request) {
 
-        Pageable pageable = PageRequest.of(0, request.limit() + 1);
+        Sort.Direction direction = Sort.Direction.fromString(request.direction());
+        Sort sort = Sort.by(direction, "ranking");
+
+        Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
+
         Slice<PopularBook> slice = bookRepository.getAllPopularBook(request, pageable);
         List<PopularBook> objectList = slice.getContent();
         Long objectCount = bookRepository.count();

--- a/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
@@ -33,8 +33,7 @@ public enum ErrorCode {
 
     // alarm
     ALARM_NOT_FOUND("알림을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
-    AlarmAccessDeniedException("알림 수정 권한 없습니다.",HttpStatus.FORBIDDEN),
-
+    ALARM_ACCES_DENIED("알림 수정 권한 없습니다.",HttpStatus.FORBIDDEN),
 
     // dashboard
 

--- a/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
 
     // alarm
     ALARM_NOT_FOUND("알림을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
-    ALARM_ACCES_DENIED("알림 수정 권한 없습니다.",HttpStatus.FORBIDDEN),
+    ALARM_ACCESS_DENIED("알림 수정 권한 없습니다.",HttpStatus.FORBIDDEN),
 
     // dashboard
 

--- a/src/test/java/com/redhorse/deokhugam/domain/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/alarm/controller/AlarmControllerTest.java
@@ -7,9 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;

--- a/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -72,7 +73,7 @@ public class DashboardServiceTest {
             mockList.add(review);
         }
 
-        given(reviewRepository.getAllPopularReview(any(DashboardRequest.class), any(Pageable.class)))
+        given(reviewRepository.getAllPopularReview(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
         given(reviewRepository.countByRequest(request)).willReturn(10L);
 
@@ -109,7 +110,7 @@ public class DashboardServiceTest {
             mockList.add(user);
         }
 
-        given(userRepository.getAllPowerUser(any(DashboardRequest.class), any(Pageable.class)))
+        given(userRepository.getAllPowerUser(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
         given(userRepository.count()).willReturn(15L);
 
@@ -144,7 +145,7 @@ public class DashboardServiceTest {
             mockList.add(book);
         }
 
-        given(bookRepository.getAllPopularBook(any(DashboardRequest.class), any(Pageable.class)))
+        given(bookRepository.getAllPopularBook(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
         given(bookRepository.count()).willReturn(3L);
 

--- a/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
@@ -75,7 +75,7 @@ public class DashboardServiceTest {
 
         given(reviewRepository.getAllPopularReview(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
-        given(reviewRepository.countByRequest(request)).willReturn(10L);
+        given(reviewRepository.countByRequest(request, LocalDate.now().minusDays(1))).willReturn(10L);
 
         given(dashboardMapper.entityToReviewDto(any(PopularReview.class)))
                 .willReturn(mock(PopularReviewDto.class));

--- a/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
@@ -112,7 +112,8 @@ public class DashboardServiceTest {
 
         given(userRepository.getAllPowerUser(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
-        given(userRepository.count()).willReturn(15L);
+        given(userRepository.countByRequestAndDate(any(DashboardRequest.class), any(LocalDate.class)))
+                .willReturn(15L);
 
         given(dashboardMapper.entityToPowerUserDto(any(PowerUser.class)))
                 .willReturn(mock(PowerUserDto.class));
@@ -147,7 +148,8 @@ public class DashboardServiceTest {
 
         given(bookRepository.getAllPopularBook(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
-        given(bookRepository.count()).willReturn(3L);
+        given(bookRepository.countByRequestAndDate(any(DashboardRequest.class), any(LocalDate.class)))
+                .willReturn(3L);
 
         given(dashboardMapper.entityToBookDto(any(PopularBook.class)))
                 .willReturn(mock(PopularBookDto.class));


### PR DESCRIPTION
## 작업 내용
> 어떤 작업을 했는지 간략히 설명해주세요.
 - 쿼리에 고정된 정렬을 요청에 따라 바뀌게 수정,
 - 에러코드에 오타 수정
 - 저장시간과 불러올 때의 시간차를 고려한 쿼리수정

## 관련 이슈
- closes #이슈번호

## 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 테스트
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료

## 참고 사항
> 리뷰어가 알아야 할 내용이 있다면 작성해주세요.

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 대시보드의 인기 콘텐츠·사용자·도서 목록이 순위별 정렬되어 표시됩니다.
  * 대시보드 조회가 직전 일자 기준으로 필터링되어 더 일관된 일별 집계가 제공됩니다.
  * 정렬이 적용된 페이지네이션으로 결과 탐색이 개선되었습니다.

* **버그 수정**
  * 오류 코드 명명 규칙이 일관되게 정리되었습니다.

* **테스트**
  * 변경된 조회 동작(일자 필터·정렬)을 반영하도록 테스트가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->