### PR TITLE
hotfix: 도서, 대시보드 수정

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/alarm/exception/AlarmAccessDeniedException.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/alarm/exception/AlarmAccessDeniedException.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public class AlarmAccessDeniedException extends AlarmException {
     public AlarmAccessDeniedException(UUID alarmId) {
-        super(ErrorCode.AlarmAccessDeniedException, Map.of("alarm", alarmId));
+        super(ErrorCode.ALARM_ACCES_DENIED, Map.of("alarm", alarmId));
     }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/alarm/exception/AlarmAccessDeniedException.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/alarm/exception/AlarmAccessDeniedException.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public class AlarmAccessDeniedException extends AlarmException {
     public AlarmAccessDeniedException(UUID alarmId) {
-        super(ErrorCode.ALARM_ACCES_DENIED, Map.of("alarm", alarmId));
+        super(ErrorCode.ALARM_ACCESS_DENIED, Map.of("alarm", alarmId));
     }
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
@@ -1,15 +1,12 @@
 package com.redhorse.deokhugam.domain.comment.repository;
 
 import com.redhorse.deokhugam.domain.comment.entity.Comment;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
 
   Optional<Comment> findByIdAndDeletedAtIsNull(UUID commentId);
 
-  long countByReviewIdAndDeletedAtIsNull(UUID reviewId);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -151,9 +151,8 @@ public class CommentServiceImpl implements CommentService {
   @Override
   @Transactional(readOnly = true)
   public CursorPageResponseCommentDto findAll(CommentPageRequest commentPageRequest) {
-    if (!reviewRepository.existsByIdAndDeletedAtIsNull(commentPageRequest.reviewId())) {
-      throw new ReviewNotFoundException(commentPageRequest.reviewId());
-    }
+    Review review = reviewRepository.findByIdAndDeletedAtIsNull(commentPageRequest.reviewId())
+        .orElseThrow(() -> new ReviewNotFoundException(commentPageRequest.reviewId()));
 
     List<Comment> comments = commentRepository.findAllByCursor(commentPageRequest);
 
@@ -169,8 +168,7 @@ public class CommentServiceImpl implements CommentService {
       nextAfter = lastComment.getCreatedAt();
     }
 
-    long totalElements = commentRepository.countByReviewIdAndDeletedAtIsNull(
-        commentPageRequest.reviewId());
+    long totalElements = review.getCommentCount();
 
     log.debug("[Comment-Service] 다건 조회 작업 완료: 결과 건수={}, 전체 건수={}, 다음 커서 존재={}",
         content.size(), totalElements, hasNext);

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> {
-
     @Query("SELECT a FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
             "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
@@ -20,4 +19,9 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
             @Param("request") DashboardRequest request,
             @Param("yesterday") LocalDate yesterday,
             Pageable pageable);
+
+    @Query("SELECT COUNT(a) FROM PopularReview a " +
+            "WHERE a.period = :#{#request.period} " +
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Long countByRequestAndDate(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
@@ -14,7 +14,6 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
 
     @Query("SELECT a FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE " +
-            "ORDER BY a.ranking DESC")
+            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE")
     Slice<PopularBook> getAllPopularBook(@Param("request") DashboardRequest request, Pageable pageable);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
@@ -20,7 +20,7 @@ public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> 
             @Param("yesterday") LocalDate yesterday,
             Pageable pageable);
 
-    @Query("SELECT COUNT(a) FROM PopularReview a " +
+    @Query("SELECT COUNT(a) FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
             "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
     Long countByRequestAndDate(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularBookRepository.java
@@ -8,12 +8,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public interface PopularBookRepository extends JpaRepository<PopularBook, UUID> {
 
     @Query("SELECT a FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE")
-    Slice<PopularBook> getAllPopularBook(@Param("request") DashboardRequest request, Pageable pageable);
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Slice<PopularBook> getAllPopularBook(
+            @Param("request") DashboardRequest request,
+            @Param("yesterday") LocalDate yesterday,
+            Pageable pageable);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
@@ -24,6 +24,6 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
 
     @Query("SELECT COUNT(a) FROM PopularReview a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE")
-    Long countByRequest(@Param("request") DashboardRequest request);
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Long countByRequest(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
@@ -8,14 +8,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public interface PopularReviewRepository extends JpaRepository<PopularReview, UUID> {
 
     @Query("SELECT a FROM PopularReview a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE ")
-    Slice<PopularReview> getAllPopularReview(@Param("request") DashboardRequest request, Pageable pageable);
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Slice<PopularReview> getAllPopularReview(
+            @Param("request") DashboardRequest request,
+            @Param("yesterday") LocalDate yesterday,
+            Pageable pageable);
 
 
     @Query("SELECT COUNT(a) FROM PopularReview a " +

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PopularReviewRepository.java
@@ -14,8 +14,7 @@ public interface PopularReviewRepository extends JpaRepository<PopularReview, UU
 
     @Query("SELECT a FROM PopularReview a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE " +
-            "ORDER BY a.ranking DESC")
+            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE ")
     Slice<PopularReview> getAllPopularReview(@Param("request") DashboardRequest request, Pageable pageable);
 
 

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
@@ -20,4 +20,9 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
             @Param("request") DashboardRequest request,
             @Param("yesterday") LocalDate yesterday,
             Pageable pageable);
+
+    @Query("SELECT COUNT(a) FROM PopularReview a " +
+            "WHERE a.period = :#{#request.period} " +
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Long countByRequestAndDate(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
@@ -14,7 +14,6 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
 
     @Query("SELECT a FROM PowerUser a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE " +
-            "ORDER BY a.ranking DESC")
+            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE ")
     Slice<PowerUser> getAllPowerUser(@Param("request") DashboardRequest request, Pageable pageable);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
@@ -21,7 +21,7 @@ public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
             @Param("yesterday") LocalDate yesterday,
             Pageable pageable);
 
-    @Query("SELECT COUNT(a) FROM PopularReview a " +
+    @Query("SELECT COUNT(a) FROM PopularBook a " +
             "WHERE a.period = :#{#request.period} " +
             "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
     Long countByRequestAndDate(@Param("request") DashboardRequest request, @Param("yesterday") LocalDate yesterday);

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/repository/PowerUserRepository.java
@@ -8,12 +8,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
 
     @Query("SELECT a FROM PowerUser a " +
             "WHERE a.period = :#{#request.period} " +
-            "AND FUNCTION('DATE', a.createdAt) = CURRENT_DATE ")
-    Slice<PowerUser> getAllPowerUser(@Param("request") DashboardRequest request, Pageable pageable);
+            "AND FUNCTION('DATE', a.createdAt) = :yesterday ")
+    Slice<PowerUser> getAllPowerUser(
+            @Param("request") DashboardRequest request,
+            @Param("yesterday") LocalDate yesterday,
+            Pageable pageable);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -44,8 +45,9 @@ public class DashboardServiceImpl implements DashboardService {
         Sort sort = Sort.by(direction, "ranking");
 
         Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
+        LocalDate yesterday = LocalDate.now().minusDays(1);
 
-        Slice<PopularReview> slice = reviewRepository.getAllPopularReview(request, pageable);
+        Slice<PopularReview> slice = reviewRepository.getAllPopularReview(request, yesterday, pageable);
         List<PopularReview> objectList = slice.getContent();
         Long objectCount = reviewRepository.countByRequest(request);
 
@@ -83,7 +85,8 @@ public class DashboardServiceImpl implements DashboardService {
         Sort sort = Sort.by(direction, "ranking");
 
         Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
-        Slice<PowerUser> slice = userRepository.getAllPowerUser(request, pageable);
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        Slice<PowerUser> slice = userRepository.getAllPowerUser(request,yesterday, pageable);
         List<PowerUser> objectList = slice.getContent();
         Long objectCount = userRepository.count();
 
@@ -120,8 +123,9 @@ public class DashboardServiceImpl implements DashboardService {
         Sort sort = Sort.by(direction, "ranking");
 
         Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
+        LocalDate yesterday = LocalDate.now().minusDays(1);
 
-        Slice<PopularBook> slice = bookRepository.getAllPopularBook(request, pageable);
+        Slice<PopularBook> slice = bookRepository.getAllPopularBook(request,yesterday, pageable);
         List<PopularBook> objectList = slice.getContent();
         Long objectCount = bookRepository.count();
 

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
@@ -49,7 +49,7 @@ public class DashboardServiceImpl implements DashboardService {
 
         Slice<PopularReview> slice = reviewRepository.getAllPopularReview(request, yesterday, pageable);
         List<PopularReview> objectList = slice.getContent();
-        Long objectCount = reviewRepository.countByRequest(request);
+        Long objectCount = reviewRepository.countByRequest(request,yesterday);
 
         String nextCursor = null;
         Instant nextAfter = null;
@@ -88,7 +88,7 @@ public class DashboardServiceImpl implements DashboardService {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         Slice<PowerUser> slice = userRepository.getAllPowerUser(request,yesterday, pageable);
         List<PowerUser> objectList = slice.getContent();
-        Long objectCount = userRepository.count();
+        Long objectCount = userRepository.countByRequestAndDate(request, yesterday);
 
         String nextCursor = null;
         Instant nextAfter = null;
@@ -127,7 +127,7 @@ public class DashboardServiceImpl implements DashboardService {
 
         Slice<PopularBook> slice = bookRepository.getAllPopularBook(request,yesterday, pageable);
         List<PopularBook> objectList = slice.getContent();
-        Long objectCount = bookRepository.count();
+        Long objectCount = bookRepository.countByRequestAndDate(request, yesterday);
 
         String nextCursor = null;
         Instant nextAfter = null;

--- a/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/dashboard/service/DashboardServiceImpl.java
@@ -40,7 +40,11 @@ public class DashboardServiceImpl implements DashboardService {
     @Cacheable(value = "popularReviews", key = "#request") // DTO가 record 타입이면 DTO자체를 키로 설정 가능
     public CursorPageResponsePopularReviewkDto getPopularReviews(DashboardRequest request) {
 
-        Pageable pageable = PageRequest.of(0, request.limit() + 1);
+        Sort.Direction direction = Sort.Direction.fromString(request.direction());
+        Sort sort = Sort.by(direction, "ranking");
+
+        Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
+
         Slice<PopularReview> slice = reviewRepository.getAllPopularReview(request, pageable);
         List<PopularReview> objectList = slice.getContent();
         Long objectCount = reviewRepository.countByRequest(request);
@@ -75,7 +79,10 @@ public class DashboardServiceImpl implements DashboardService {
     @Cacheable(value = "powerUsers", key = "#request")
     public CursorPageResponsePowerUserDto getPowerUsers(DashboardRequest request) {
 
-        Pageable pageable = PageRequest.of(0, request.limit() + 1);
+        Sort.Direction direction = Sort.Direction.fromString(request.direction());
+        Sort sort = Sort.by(direction, "ranking");
+
+        Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
         Slice<PowerUser> slice = userRepository.getAllPowerUser(request, pageable);
         List<PowerUser> objectList = slice.getContent();
         Long objectCount = userRepository.count();
@@ -109,7 +116,11 @@ public class DashboardServiceImpl implements DashboardService {
     @Cacheable(value = "popularBooks", key = "#request")
     public CursorPageResponsePopularBookDto getPopularBooks(DashboardRequest request) {
 
-        Pageable pageable = PageRequest.of(0, request.limit() + 1);
+        Sort.Direction direction = Sort.Direction.fromString(request.direction());
+        Sort sort = Sort.by(direction, "ranking");
+
+        Pageable pageable = PageRequest.of(0, request.limit() + 1, sort);
+
         Slice<PopularBook> slice = bookRepository.getAllPopularBook(request, pageable);
         List<PopularBook> objectList = slice.getContent();
         Long objectCount = bookRepository.count();

--- a/src/main/java/com/redhorse/deokhugam/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/review/repository/ReviewRepository.java
@@ -25,8 +25,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRep
     @Cacheable(value = "review", key = "#reviewId")
     Optional<Review> findByIdAndDeletedAtIsNull(UUID reviewId);
 
-    boolean existsByIdAndDeletedAtIsNull(UUID id);
-
     boolean existsByBookIdAndUserIdAndDeletedAtIsNull(UUID bookId, UUID userId);
 
     @Query("SELECT COUNT(r) FROM Review r WHERE r.book.id = :bookId AND r.deletedAt IS NULL")

--- a/src/main/java/com/redhorse/deokhugam/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/review/repository/ReviewRepository.java
@@ -30,7 +30,7 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRep
     boolean existsByBookIdAndUserIdAndDeletedAtIsNull(UUID bookId, UUID userId);
 
     @Query("SELECT COUNT(r) FROM Review r WHERE r.book.id = :bookId AND r.deletedAt IS NULL")
-    long countByBookId(UUID bookId);
+    long countByBookId(@Param("bookId") UUID bookId);
 
     @Query("SELECT AVG(r.rating) FROM Review r WHERE r.book.id = :bookId AND r.deletedAt IS NULL")
     Double averageRatingByBookId(@Param("bookId") UUID bookId);

--- a/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
@@ -33,8 +33,7 @@ public enum ErrorCode {
 
     // alarm
     ALARM_NOT_FOUND("알림을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
-    AlarmAccessDeniedException("알림 수정 권한 없습니다.",HttpStatus.FORBIDDEN),
-
+    ALARM_ACCES_DENIED("알림 수정 권한 없습니다.",HttpStatus.FORBIDDEN),
 
     // dashboard
 

--- a/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/redhorse/deokhugam/global/exception/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
 
     // alarm
     ALARM_NOT_FOUND("알림을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
-    ALARM_ACCES_DENIED("알림 수정 권한 없습니다.",HttpStatus.FORBIDDEN),
+    ALARM_ACCESS_DENIED("알림 수정 권한 없습니다.",HttpStatus.FORBIDDEN),
 
     // dashboard
 

--- a/src/main/java/com/redhorse/deokhugam/infra/s3/S3ImageStorage.java
+++ b/src/main/java/com/redhorse/deokhugam/infra/s3/S3ImageStorage.java
@@ -26,7 +26,7 @@ public class S3ImageStorage
     @Value("${storage.s3.bucket}")
     private String bucket;
 
-    @Value("${storage.s3.expiration-duration-in-minutes:10}")
+    @Value("${storage.s3.expiration-duration-in-minutes:10080}")
     private long expirationDurationInMinutes;
 
     private final S3Client s3Client;

--- a/src/main/java/com/redhorse/deokhugam/infra/s3/scheduler/LogUploadScheduler.java
+++ b/src/main/java/com/redhorse/deokhugam/infra/s3/scheduler/LogUploadScheduler.java
@@ -80,8 +80,6 @@ public class LogUploadScheduler
         for (String pathStr : failedPaths) {
             try {
                 s3LogStorage.upload(Paths.get(pathStr));
-                stillFailed.remove(pathStr);
-                Files.write(failedFile, stillFailed);
                 log.info("[Log-Scheduler] 재업로드 성공: path={}", pathStr);
             } catch (S3UploadException e) {
                 log.error("[Log-Scheduler] 재업로드 실패: path={}", pathStr);
@@ -106,7 +104,7 @@ public class LogUploadScheduler
             s3LogStorage.upload(path);
         } catch (S3UploadException e) {
             log.error("[Log-Scheduler] 로그 파일 업로드 실패, 실패 목록에 저장: path={}", path);
-            saveFiledPath(path);
+            saveFailedPath(path);
         }
     }
 
@@ -115,7 +113,7 @@ public class LogUploadScheduler
      *
      * @param path 저장할 실패 파일 경로
      */
-    private void saveFiledPath(Path path) {
+    private void saveFailedPath(Path path) {
         Path failedFile = Paths.get(logDir, FAILED_UPLOADS_FILE);
 
         try {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -79,7 +79,7 @@ storage:
     secret-key: ${AWS_SECRET_KEY}
     region: ${AWS_S3_REGION}
     bucket: ${AWS_S3_BUCKET}
-    expiration-duration-in-minutes: ${AWS_S3_PRESIGNED_URL_EXPIRATION_MINUTES:10}
+    expiration-duration-in-minutes: ${AWS_S3_PRESIGNED_URL_EXPIRATION_MINUTES:10080}
 
 # resilience4j
 resilience4j:

--- a/src/test/java/com/redhorse/deokhugam/domain/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/alarm/controller/AlarmControllerTest.java
@@ -7,9 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
@@ -451,7 +451,11 @@ class CommentServiceTest {
       int limit = 5;
       CommentPageRequest request = new CommentPageRequest(reviewId, "DESC", null, null, limit);
 
-      given(reviewRepository.existsByIdAndDeletedAtIsNull(reviewId)).willReturn(true);
+      Review mockReview = mock(Review.class);
+      given(mockReview.getCommentCount()).willReturn(10L);
+
+      given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId))
+          .willReturn(Optional.of(mockReview));
 
       List<Comment> mockComments = new ArrayList<>();
       for (int i = 0; i < limit + 1 ; i++) {
@@ -466,7 +470,6 @@ class CommentServiceTest {
       Comment lastCommentOfContent = mockComments.get(limit - 1);
 
       given(commentRepository.findAllByCursor(request)).willReturn(mockComments);
-      given(commentRepository.countByReviewIdAndDeletedAtIsNull(eq(reviewId))).willReturn(10L);
       given(commentMapper.toDto(any(Comment.class))).willReturn(mock(CommentDto.class));
 
       // when
@@ -488,7 +491,7 @@ class CommentServiceTest {
       UUID invalidReviewId = UUID.randomUUID();
       CommentPageRequest request = new CommentPageRequest(invalidReviewId, "DESC", null, null, 5);
 
-      given(reviewRepository.existsByIdAndDeletedAtIsNull(eq(invalidReviewId))).willReturn(false);
+      given(reviewRepository.findByIdAndDeletedAtIsNull(eq(invalidReviewId))).willReturn(Optional.empty());
 
       // when & then
       assertThatThrownBy(() -> commentService.findAll(request))

--- a/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -72,7 +73,7 @@ public class DashboardServiceTest {
             mockList.add(review);
         }
 
-        given(reviewRepository.getAllPopularReview(any(DashboardRequest.class), any(Pageable.class)))
+        given(reviewRepository.getAllPopularReview(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
         given(reviewRepository.countByRequest(request)).willReturn(10L);
 
@@ -109,7 +110,7 @@ public class DashboardServiceTest {
             mockList.add(user);
         }
 
-        given(userRepository.getAllPowerUser(any(DashboardRequest.class), any(Pageable.class)))
+        given(userRepository.getAllPowerUser(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
         given(userRepository.count()).willReturn(15L);
 
@@ -144,7 +145,7 @@ public class DashboardServiceTest {
             mockList.add(book);
         }
 
-        given(bookRepository.getAllPopularBook(any(DashboardRequest.class), any(Pageable.class)))
+        given(bookRepository.getAllPopularBook(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
         given(bookRepository.count()).willReturn(3L);
 

--- a/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
@@ -75,7 +75,7 @@ public class DashboardServiceTest {
 
         given(reviewRepository.getAllPopularReview(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
-        given(reviewRepository.countByRequest(request)).willReturn(10L);
+        given(reviewRepository.countByRequest(request, LocalDate.now().minusDays(1))).willReturn(10L);
 
         given(dashboardMapper.entityToReviewDto(any(PopularReview.class)))
                 .willReturn(mock(PopularReviewDto.class));

--- a/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/dashboard/DashboardServiceTest.java
@@ -112,7 +112,8 @@ public class DashboardServiceTest {
 
         given(userRepository.getAllPowerUser(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
-        given(userRepository.count()).willReturn(15L);
+        given(userRepository.countByRequestAndDate(any(DashboardRequest.class), any(LocalDate.class)))
+                .willReturn(15L);
 
         given(dashboardMapper.entityToPowerUserDto(any(PowerUser.class)))
                 .willReturn(mock(PowerUserDto.class));
@@ -147,7 +148,8 @@ public class DashboardServiceTest {
 
         given(bookRepository.getAllPopularBook(any(DashboardRequest.class),  any(LocalDate.class), any(Pageable.class)))
                 .willReturn(new SliceImpl<>(mockList));
-        given(bookRepository.count()).willReturn(3L);
+        given(bookRepository.countByRequestAndDate(any(DashboardRequest.class), any(LocalDate.class)))
+                .willReturn(3L);
 
         given(dashboardMapper.entityToBookDto(any(PopularBook.class)))
                 .willReturn(mock(PopularBookDto.class));


### PR DESCRIPTION
## 작업 내용

Book
- presigned URL 만료 시간을 조정
- 로그 업로드 재시도 로직을 수정

DashBoard
- 데이터의 저장하고 불러올 때 적용되는 시간이 달라서 데이터를 못불러오던 문제를 수정

Comment
-  댓글 목록 조회 최적화

## 관련 이슈
- closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * S3 파일 링크 기본 유효 기간이 10분에서 7일로 연장되었습니다.
  * 대시보드에 정렬 기능이 추가되어 요청 방향에 따라 결과가 정렬됩니다.
  * 대시보드 조회가 날짜 기준(어제)으로 필터링되도록 개선되었습니다.

* **버그 수정**
  * 알람 접근 권한 관련 오류 코드가 정리되어 접근 제어 처리 안정성이 향상되었습니다.

* **작업(Chores)**
  * 로그 업로드 재시도 및 실패 기록 처리 방식이 변경되었습니다.

* **테스트**
  * 대시보드 및 댓글 관련 테스트가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->