### PR TITLE
refactor: 댓글 목록 조회 최적화

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
@@ -1,15 +1,12 @@
 package com.redhorse.deokhugam.domain.comment.repository;
 
 import com.redhorse.deokhugam.domain.comment.entity.Comment;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
 
   Optional<Comment> findByIdAndDeletedAtIsNull(UUID commentId);
 
-  long countByReviewIdAndDeletedAtIsNull(UUID reviewId);
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -151,9 +151,8 @@ public class CommentServiceImpl implements CommentService {
   @Override
   @Transactional(readOnly = true)
   public CursorPageResponseCommentDto findAll(CommentPageRequest commentPageRequest) {
-    if (!reviewRepository.existsByIdAndDeletedAtIsNull(commentPageRequest.reviewId())) {
-      throw new ReviewNotFoundException(commentPageRequest.reviewId());
-    }
+    Review review = reviewRepository.findByIdAndDeletedAtIsNull(commentPageRequest.reviewId())
+        .orElseThrow(() -> new ReviewNotFoundException(commentPageRequest.reviewId()));
 
     List<Comment> comments = commentRepository.findAllByCursor(commentPageRequest);
 
@@ -169,8 +168,7 @@ public class CommentServiceImpl implements CommentService {
       nextAfter = lastComment.getCreatedAt();
     }
 
-    long totalElements = commentRepository.countByReviewIdAndDeletedAtIsNull(
-        commentPageRequest.reviewId());
+    long totalElements = review.getCommentCount();
 
     log.debug("[Comment-Service] 다건 조회 작업 완료: 결과 건수={}, 전체 건수={}, 다음 커서 존재={}",
         content.size(), totalElements, hasNext);

--- a/src/main/java/com/redhorse/deokhugam/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/review/repository/ReviewRepository.java
@@ -25,8 +25,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRep
     @Cacheable(value = "review", key = "#reviewId")
     Optional<Review> findByIdAndDeletedAtIsNull(UUID reviewId);
 
-    boolean existsByIdAndDeletedAtIsNull(UUID id);
-
     boolean existsByBookIdAndUserIdAndDeletedAtIsNull(UUID bookId, UUID userId);
 
     @Query("SELECT COUNT(r) FROM Review r WHERE r.book.id = :bookId AND r.deletedAt IS NULL")

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
@@ -451,7 +451,11 @@ class CommentServiceTest {
       int limit = 5;
       CommentPageRequest request = new CommentPageRequest(reviewId, "DESC", null, null, limit);
 
-      given(reviewRepository.existsByIdAndDeletedAtIsNull(reviewId)).willReturn(true);
+      Review mockReview = mock(Review.class);
+      given(mockReview.getCommentCount()).willReturn(10L);
+
+      given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId))
+          .willReturn(Optional.of(mockReview));
 
       List<Comment> mockComments = new ArrayList<>();
       for (int i = 0; i < limit + 1 ; i++) {
@@ -466,7 +470,6 @@ class CommentServiceTest {
       Comment lastCommentOfContent = mockComments.get(limit - 1);
 
       given(commentRepository.findAllByCursor(request)).willReturn(mockComments);
-      given(commentRepository.countByReviewIdAndDeletedAtIsNull(eq(reviewId))).willReturn(10L);
       given(commentMapper.toDto(any(Comment.class))).willReturn(mock(CommentDto.class));
 
       // when
@@ -488,7 +491,7 @@ class CommentServiceTest {
       UUID invalidReviewId = UUID.randomUUID();
       CommentPageRequest request = new CommentPageRequest(invalidReviewId, "DESC", null, null, 5);
 
-      given(reviewRepository.existsByIdAndDeletedAtIsNull(eq(invalidReviewId))).willReturn(false);
+      given(reviewRepository.findByIdAndDeletedAtIsNull(eq(invalidReviewId))).willReturn(Optional.empty());
 
       // when & then
       assertThatThrownBy(() -> commentService.findAll(request))


### PR DESCRIPTION
## 작업 내용
> 어떤 작업을 했는지 간략히 설명해주세요.
- 댓글 목록 조회 로직을 최적화했습니다.
- 기존 리뷰가 유효한지 조회하는 쿼리 한 번 + totalElement를 계산하는 count 쿼리 한번이었지만
- 현재 리뷰 조회 한번으로 count 쿼리 쓰지 않아도 되도록 수정했습니다.

## 관련 이슈

## 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 테스트
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료

## 참고 사항
> 리뷰어가 알아야 할 내용이 있다면 작성해주세요.

### 스크린샷 (선택)
- 한 리뷰에 댓글 100개 존재
- 반복 50번, 각 요청 사이에 delay 100ms 두기
- 댓글 목록 최적화 전
<img width="1551" height="903" alt="댓글 최적화 전" src="https://github.com/user-attachments/assets/9da8b0a0-10ee-4fd3-b337-b6443eec6a1c" />
- 평균 응답 시간: 53ms

- 댓글 목록 최적화 후
<img width="1554" height="900" alt="댓글 최적화 후" src="https://github.com/user-attachments/assets/1d0f0db1-e5b6-4a01-a1ee-3caa1dffbc07" />
- 평균 응답 시간: 23ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 리뷰 및 댓글 조회 시 데이터베이스 쿼리 최적화로 응답 속도 개선
  * 조회 로직 간소화로 시스템 효율성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->