### PR TITLE
fix: 댓글 삭제 관련 댓글수 카운트 정합성 해결

### DIFF
--- a/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
 
-  @EntityGraph(attributePaths = {"review", "user"})
+  @EntityGraph(attributePaths = {"user"})
   Optional<Comment> findByIdAndDeletedAtIsNull(UUID commentId);
 
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/repository/CommentRepository.java
@@ -3,10 +3,12 @@ package com.redhorse.deokhugam.domain.comment.repository;
 import com.redhorse.deokhugam.domain.comment.entity.Comment;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
 
+  @EntityGraph(attributePaths = {"review", "user"})
   Optional<Comment> findByIdAndDeletedAtIsNull(UUID commentId);
 
 }

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -109,15 +109,16 @@ public class CommentServiceImpl implements CommentService {
       throw new CommentDeleteNotAllowedException(commentId);
     }
 
-    comment.softDelete();
-
     // 삭제 처리 트랜잭션동안 락 걸기
-    Review review = reviewRepository.findByIdForUpdate(comment.getReview().getId())
-        .orElseThrow(() -> new ReviewNotFoundException(comment.getReview().getId()));
+    UUID reviewId = comment.getReview().getId();
+    Review review = reviewRepository.findByIdForUpdate(reviewId)
+        .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+
+    comment.softDelete();
     review.decrementCommentCount();
 
     Optional.ofNullable(cacheManager.getCache("review"))
-        .ifPresent(cache -> cache.evict(review.getId()));
+        .ifPresent(cache -> cache.evict(reviewId));
 
     log.info("[Comment-Service] 논리 삭제 작업 완료: commentId={}", commentId);
   }
@@ -140,12 +141,13 @@ public class CommentServiceImpl implements CommentService {
     // 논리 삭제가 이루어지지 않은 경우에만 count 깎기
     if (comment.getDeletedAt() == null) {
       // 삭제 처리 트랜잭션동안 락 걸기
-      Review review = reviewRepository.findByIdForUpdate(comment.getReview().getId())
-          .orElseThrow(() -> new ReviewNotFoundException(comment.getReview().getId()));
+      UUID reviewId = comment.getReview().getId();
+      Review review = reviewRepository.findByIdForUpdate(reviewId)
+          .orElseThrow(() -> new ReviewNotFoundException(reviewId));
       review.decrementCommentCount();
 
       Optional.ofNullable(cacheManager.getCache("review"))
-          .ifPresent(cache -> cache.evict(comment.getReview().getId()));
+          .ifPresent(cache -> cache.evict(reviewId));
     }
 
     commentRepository.delete(comment);

--- a/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -40,7 +40,7 @@ public class CommentServiceImpl implements CommentService {
   private final CacheManager cacheManager;
 
   @Caching(evict = {
-          @CacheEvict(value = "review", key = "#commentCreateRequest.reviewId()")
+      @CacheEvict(value = "review", key = "#commentCreateRequest.reviewId()")
   })
   @Override
   public CommentDto create(CommentCreateRequest commentCreateRequest) {
@@ -96,7 +96,7 @@ public class CommentServiceImpl implements CommentService {
   }
 
   @Caching(evict = {
-          @CacheEvict(value = "comment", key = "#commentId")
+      @CacheEvict(value = "comment", key = "#commentId")
   })
   @Override
   public void softDelete(UUID commentId, UUID requestUserId) {
@@ -110,17 +110,20 @@ public class CommentServiceImpl implements CommentService {
     }
 
     comment.softDelete();
-    Review review = comment.getReview();
+
+    // 삭제 처리 트랜잭션동안 락 걸기
+    Review review = reviewRepository.findByIdForUpdate(comment.getReview().getId())
+        .orElseThrow(() -> new ReviewNotFoundException(comment.getReview().getId()));
     review.decrementCommentCount();
 
     Optional.ofNullable(cacheManager.getCache("review"))
-                    .ifPresent(cache -> cache.evict(review.getId()));
+        .ifPresent(cache -> cache.evict(review.getId()));
 
     log.info("[Comment-Service] 논리 삭제 작업 완료: commentId={}", commentId);
   }
 
   @Caching(evict = {
-          @CacheEvict(value = "comment", key = "#commentId")
+      @CacheEvict(value = "comment", key = "#commentId")
   })
   @Override
   public void hardDelete(UUID commentId, UUID requestUserId) {
@@ -136,7 +139,9 @@ public class CommentServiceImpl implements CommentService {
 
     // 논리 삭제가 이루어지지 않은 경우에만 count 깎기
     if (comment.getDeletedAt() == null) {
-      Review review = comment.getReview();
+      // 삭제 처리 트랜잭션동안 락 걸기
+      Review review = reviewRepository.findByIdForUpdate(comment.getReview().getId())
+          .orElseThrow(() -> new ReviewNotFoundException(comment.getReview().getId()));
       review.decrementCommentCount();
 
       Optional.ofNullable(cacheManager.getCache("review"))

--- a/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/redhorse/deokhugam/domain/comment/service/CommentServiceTest.java
@@ -268,19 +268,21 @@ class CommentServiceTest {
       // given
       UUID commentId = UUID.randomUUID();
       UUID requestUserId = UUID.randomUUID();
+      UUID reviewId = UUID.randomUUID();
 
       given(userRepository.existsById(requestUserId)).willReturn(true);
 
       User mockUser = mock(User.class);
-      given(mockUser.getId()).willReturn(requestUserId);
-
       Review mockReview = mock(Review.class);
-
       Comment mockComment = mock(Comment.class);
+
+      given(mockUser.getId()).willReturn(requestUserId);
       given(mockComment.getUser()).willReturn(mockUser);
       given(mockComment.getReview()).willReturn(mockReview);
-      given(commentRepository.findByIdAndDeletedAtIsNull(eq(commentId))).willReturn(
-          Optional.of(mockComment));
+      given(mockReview.getId()).willReturn(reviewId);
+
+      given(commentRepository.findByIdAndDeletedAtIsNull(eq(commentId))).willReturn(Optional.of(mockComment));
+      given(reviewRepository.findByIdForUpdate(eq(reviewId))).willReturn(Optional.of(mockReview));
 
       Cache cache = mock(Cache.class);
       given(cacheManager.getCache("review")).willReturn(cache);
@@ -291,6 +293,8 @@ class CommentServiceTest {
       // then
       then(commentRepository).should().findByIdAndDeletedAtIsNull(eq(commentId));
       then(mockComment).should().softDelete();
+      then(reviewRepository).should().findByIdForUpdate(eq(reviewId));
+      then(mockReview).should().decrementCommentCount();
     }
 
     @Test
@@ -360,18 +364,21 @@ class CommentServiceTest {
       // given
       UUID commentId = UUID.randomUUID();
       UUID requestUserId = UUID.randomUUID();
+      UUID reviewId = UUID.randomUUID();
 
       given(userRepository.existsById(requestUserId)).willReturn(true);
 
       User mockUser = mock(User.class);
-      given(mockUser.getId()).willReturn(requestUserId);
-
-      Comment mockComment = mock(Comment.class);
-      given(mockComment.getUser()).willReturn(mockUser);
-      given(commentRepository.findById(eq(commentId))).willReturn(Optional.of(mockComment));
-
       Review mockReview = mock(Review.class);
+      Comment mockComment = mock(Comment.class);
+
+      given(mockUser.getId()).willReturn(requestUserId);
+      given(mockComment.getUser()).willReturn(mockUser);
       given(mockComment.getReview()).willReturn(mockReview);
+      given(mockReview.getId()).willReturn(reviewId);
+
+      given(commentRepository.findById(eq(commentId))).willReturn(Optional.of(mockComment));
+      given(reviewRepository.findByIdForUpdate(eq(reviewId))).willReturn(Optional.of(mockReview));
 
       Cache cache = mock(Cache.class);
       given(cacheManager.getCache("review")).willReturn(cache);
@@ -382,6 +389,8 @@ class CommentServiceTest {
       // then
       then(commentRepository).should().findById(eq(commentId));
       then(commentRepository).should().delete(eq(mockComment));
+      then(reviewRepository).should().findByIdForUpdate(eq(reviewId));
+      then(mockReview).should().decrementCommentCount();
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
> 어떤 작업을 했는지 간략히 설명해주세요.
- 댓글 동시 삭제 처리될 경우 리뷰 조회에 락을 걸어서 카운트의 정합성을 지켰습니다.

## 관련 이슈
- closes #이슈번호

## 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 테스트
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료

## 참고 사항
> 리뷰어가 알아야 할 내용이 있다면 작성해주세요.

### 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 댓글 삭제(소프트/하드) 처리 시 관련 데이터 일관성 및 동시성 안정성 강화
  * 삭제 시 댓글 수 카운트 감소와 캐시 갱신이 올바른 대상에 적용되도록 수정
* **성능 개선**
  * 댓글 조회 시 관련 리뷰와 사용자 정보를 함께 불러와 조회 효율성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->